### PR TITLE
Make daemon recycling configurable

### DIFF
--- a/src/configuration.c
+++ b/src/configuration.c
@@ -44,7 +44,8 @@ const char *config_key_int[] = { NULL, "record_expiry", "spool_max_size",
                                  "byte_window_length", "record_burst_limit",
                                  "byte_burst_limit", NULL };
 
-const char *config_key_bool[] = { NULL, "rate_limit_enabled", NULL };
+const char *config_key_bool[] = { NULL, "rate_limit_enabled",
+				  "daemon_recycling_enabled", NULL };
 
 static struct configuration config = { { 0 }, { 0 }, { 0 }, false, NULL };
 
@@ -333,5 +334,11 @@ const char *rate_limit_strategy_config()
         }
 
         return val;
+}
+
+bool daemon_recycling_enabled_config(void)
+{
+	initialize_config();
+	return config.boolValues[CONF_DAEMON_RECYCLING_ENABLED];
 }
 /* vi: set ts=8 sw=8 sts=4 et tw=80 cino=(0: */

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -46,6 +46,7 @@ enum config_int_keys {
 enum config_bool_keys {
         CONF_BOOL_MIN = 0,
         CONF_RATE_LIMIT_ENABLED,
+	CONF_DAEMON_RECYCLING_ENABLED,
         CONF_BOOL_MAX
 };
 
@@ -112,5 +113,8 @@ const char *get_cainfo_config(void);
 
 /* Gets tidheader */
 const char *get_tidheader_config(void);
+
+/* Gets whether recycling is enabled */
+bool daemon_recycling_enabled_config(void);
 
 /* vi: set ts=8 sw=8 sts=4 et tw=80 cino=(0: */

--- a/src/data/example.conf
+++ b/src/data/example.conf
@@ -35,3 +35,6 @@ rate_limit_enabled=true
 
 #rate limit strategy if record not send
 rate_limit_strategy=spool
+
+#daemon recycling enabled
+daemon_recycling_enabled=true

--- a/src/data/telemetrics.conf.in
+++ b/src/data/telemetrics.conf.in
@@ -51,3 +51,7 @@ byte_window_length=20
 # Valid stategies: spool, drop
 rate_limit_strategy=spool
 
+# daemon recycling enabled - if daemon has been running for a while (2 hours),
+# has not any client nor spool data, then it exits.
+# this is to ensure that latest code runs.
+daemon_recycling_enabled=true

--- a/src/main.c
+++ b/src/main.c
@@ -232,6 +232,8 @@ int main(int argc, char **argv)
         time_t last_spool_run_time = time(NULL);
         time_t last_daemon_start_time = time(NULL);
 
+	bool daemon_recycling_enabled = daemon_recycling_enabled_config();
+
         ret = update_machine_id();
         if (ret == -1) {
                 telem_log(LOG_ERR, "Unable to update machine id\n");
@@ -336,7 +338,7 @@ int main(int argc, char **argv)
                 } else {
                         time_t now = time(NULL);
                         /* If spool is empty and time to recycle the daemon has elapsed*/
-                        if ((daemon.current_spool_size == 0) &&
+			if (daemon_recycling_enabled && (daemon.current_spool_size == 0) &&
                             difftime(now, last_daemon_start_time) >= TM_DAEMON_EXIT_TIME) {
                                 /* Exit */
                                 telem_log(LOG_INFO, "Daemon exiting for recycling\n");

--- a/tests/check_config.c
+++ b/tests/check_config.c
@@ -50,6 +50,7 @@ START_TEST(check_read_valid_config)
         ck_assert_str_eq(config.strValues[CONF_CAINFO], "/tmp/cacert.crt");
         ck_assert_str_eq(config.strValues[CONF_TIDHEADER],
                          "X-Telemetry-TID: 6907c830-eed9-4ce9-81ae-76daf8d88f0f");
+	ck_assert(config.boolValues[CONF_DAEMON_RECYCLING_ENABLED] == true);
 
 }
 END_TEST
@@ -75,6 +76,7 @@ START_TEST(check_config_initialised)
         ck_assert_str_eq(get_cainfo_config(), "/tmp/cacert.crt");
         ck_assert_str_eq(get_tidheader_config(),
                          "X-Telemetry-TID: 6907c830-eed9-4ce9-81ae-76daf8d88f0f");
+	ck_assert(daemon_recycling_enabled_config() == true);
 }
 END_TEST
 


### PR DESCRIPTION
The user may want to disable recycling (daemon auto exit).
This can be the case if telemd daemon is not configured
to respawn or if service is automatically restarted by
the system after package update.

This patch introduces the daemon_recycling_enabled config
entry.