### PR TITLE
crashprobe: fix stderr when launched from kernel

### DIFF
--- a/src/probes/crash_probe.c
+++ b/src/probes/crash_probe.c
@@ -380,6 +380,14 @@ int main(int argc, char **argv)
         GError *error = NULL;
         GOptionContext *context;
 
+        if (fcntl(STDERR_FILENO, F_GETFL) < 0) {
+                // redirect stderr to avoid bad things to happen with
+                // fd 2 when launched from kernel core pattern
+                if (freopen("/dev/null", "w", stderr) == NULL) {
+                        exit(EXIT_FAILURE);
+                }
+        }
+
         // Since this program handles core files, make sure it does not produce
         // core files itself, or else it will be invoked endlessly...
         prctl(PR_SET_DUMPABLE, 0);


### PR DESCRIPTION
stderr could be used for logging or in libtelemetry in DEBUG mode but
when crashprobe is launched through kernel core_pattern, stderr is not
open, only stdin (fd 0), see this dump from gdb:

 (gdb) shell ls -l /proc/15478/fd
 total 0
 lr-x------ 1 root root 64 24 juin  15:02 0 -> pipe:[82555]

If stderr is not open, when socket to telemd is open it could take
fd 2 and in this case all fprint to stderr are written to socket which
is bad ... this is the case when doing static linking, which ends to
telemd crashed.

Fix it by ensuring stderr is open.

Signed-off-by: Jeremy Rocher <jeremy.rocher@intel.com>