### PR TITLE
Add opt-in feature to disable privacy filters

### DIFF
--- a/src/probes/crash_probe.c
+++ b/src/probes/crash_probe.c
@@ -403,17 +403,17 @@ static bool in_clr_build(gchar *fullpath)
         return false;
 }
 
-static bool filter_binaries(gchar *fullpath)
+static bool is_banned_path(gchar *fullpath)
 {
         // Anything outside of /usr/, or in /usr/local/, we consider third-party
         if (g_regex_match_simple("^[!/]usr[!/]", fullpath, 0, 0) == FALSE) {
-                return false;
+                return true;
         } else if (g_regex_match_simple("^[!/]usr[!/]local[!/]", fullpath,
                                         0, 0) == TRUE) {
-                return false;
+                return true;
         }
 
-        return true;
+        return false;
 }
 
 static gchar *config_file = NULL;
@@ -506,7 +506,7 @@ int main(int argc, char **argv)
                 goto success;
         }
 
-        if (proc_path && !filter_binaries(proc_path)) {
+        if (proc_path && is_banned_path(proc_path)) {
                 telem_log(LOG_NOTICE, "Ignoring core (third-party binary)\n");
 
                 backtrace = g_string_new("Crash from third party\n");

--- a/src/probes/crash_probe.c
+++ b/src/probes/crash_probe.c
@@ -38,6 +38,7 @@
 
 #include "config.h"
 #include "log.h"
+#include "probe.h"
 #include "telemetry.h"
 
 static Dwfl *d_core = NULL;
@@ -391,6 +392,11 @@ fail:
 
 static bool in_clr_build(gchar *fullpath)
 {
+        // Global override for privacy filters
+        if (access(TM_PRIVACY_FILTERS_OVERRIDE, F_OK) == 0) {
+                return false;
+        }
+
         /*
          * The build environment for Clear Linux packages is set up by 'mock',
          * and the chroot in which rpmbuild builds the packages has this prefix.
@@ -405,6 +411,11 @@ static bool in_clr_build(gchar *fullpath)
 
 static bool is_banned_path(gchar *fullpath)
 {
+        // Global override for privacy filters
+        if (access(TM_PRIVACY_FILTERS_OVERRIDE, F_OK) == 0) {
+                return false;
+        }
+
         // Anything outside of /usr/, or in /usr/local/, we consider third-party
         if (g_regex_match_simple("^[!/]usr[!/]", fullpath, 0, 0) == FALSE) {
                 return true;

--- a/src/probes/local.mk
+++ b/src/probes/local.mk
@@ -44,7 +44,8 @@ endif
 
 
 %C%_crashprobe_SOURCES = \
-	%D%/crash_probe.c
+	%D%/crash_probe.c \
+	%D%/probe.h
 %C%_crashprobe_CFLAGS = \
 	$(AM_CFLAGS) \
 	$(GLIB_CFLAGS)
@@ -120,7 +121,8 @@ endif
 
 %C%_oopsprobe_SOURCES = \
         %D%/oops_probe.c \
-	%D%/oops_parser.c
+	%D%/oops_parser.c \
+	%D%/probe.h
 %C%_oopsprobe_CFLAGS = \
         $(AM_CFLAGS) \
         $(GLIB_CFLAGS)

--- a/src/probes/oops_parser.c
+++ b/src/probes/oops_parser.c
@@ -21,9 +21,11 @@
 #include <string.h>
 #include <ctype.h>
 #include <inttypes.h>
+#include <unistd.h>
 
 #include "oops_parser.h"
 #include "log.h"
+#include "probe.h"
 
 #define NUM_TAINTED_FLAGS 16
 
@@ -704,13 +706,14 @@ void append_registers_to_bt(GString **backtrace)
         struct reg_s *reg_entry = reg_head;
 
         while (reg_entry != NULL) {
-                #ifdef DEBUG
-                g_string_append_printf(*backtrace, "Register %s: %" PRIx64 "\n", reg_entry->reg_name,
-                                       reg_entry->reg_value);
-                #else
-                g_string_append_printf(*backtrace, "Register %s: %s\n", reg_entry->reg_name,
-                                       reg_entry->reg_value ? "Non-zero" : "Zero");
-                #endif
+                // Global override for privacy filters
+                if (access(TM_PRIVACY_FILTERS_OVERRIDE, F_OK) == 0) {
+                        g_string_append_printf(*backtrace, "Register %s: %" PRIx64 "\n", reg_entry->reg_name,
+                                               reg_entry->reg_value);
+                } else {
+                        g_string_append_printf(*backtrace, "Register %s: %s\n", reg_entry->reg_name,
+                                               reg_entry->reg_value ? "Non-zero" : "Zero");
+                }
                 reg_entry = reg_entry->next;
         }
 

--- a/src/probes/probe.h
+++ b/src/probes/probe.h
@@ -1,0 +1,26 @@
+/*
+ * This program is part of the Clear Linux Project
+ *
+ * Copyright 2017 Intel Corporation
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms and conditions of the GNU Lesser General Public License, as
+ * published by the Free Software Foundation; either version 2.1 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+#pragma once
+
+/**
+ * Existence of the opt-in-no-privacy-filters file disables certain privacy
+ * filters enforced in telemetry probes.
+ */
+#define TM_PRIVACY_FILTERS_OVERRIDE "/etc/telemetrics/opt-in-no-privacy-filters"
+
+
+/* vi: set ts=8 sw=8 sts=4 et tw=80 cino=(0: */


### PR DESCRIPTION
There are some filters in place that prevent probes from collecting
specific types of data. In particular, the oops probe will report "zero"
or "non-zero" for register values in oopses instead of the actual
values. And the crash probe does not send backtraces if binaries live
outside of `/usr` or under `/usr/local`.

This commit keeps these filters in place but offers the capability to
disable the filters by creating a file named

```
/etc/telemetrics/opt-in-no-privacy-filters
```

Any future telemetry privacy filters can check for this file to alter
the reporting level.