### PR TITLE
Properly init/deinit environment for libcurl

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -30,6 +30,7 @@
 #include <sys/signalfd.h>
 #include <signal.h>
 #include <malloc.h>
+#include <curl/curl.h>
 
 #include "config.h"
 #include "common.h"
@@ -120,6 +121,8 @@ int main(int argc, char **argv)
                 }
         }
         initialize_daemon(&daemon);
+
+        curl_global_init(CURL_GLOBAL_ALL);
 
         sigemptyset(&mask);
 
@@ -371,6 +374,8 @@ clean_exit:
         if (LIST_EMPTY(&(daemon.client_head))) {
                 telem_log(LOG_INFO, "Client list cleared\n");
         }
+
+        curl_global_cleanup();
 
         return 0;
 }


### PR DESCRIPTION
The libcurl documentation states that curl_global_init() "must" be called within a program that uses the library, but because the libcurl integration code has been working for a long time, this is clearly not an absolute requirement.

We did however detect a memory resource leak that is fixed by adding calls to curl_global_init() and curl_global_cleanup(), so add the appropriate calls to fix the issue.