### PR TITLE
Init/deinit libcurl global environment for each POST

### DIFF
--- a/src/telemdaemon.c
+++ b/src/telemdaemon.c
@@ -462,6 +462,11 @@ bool post_record_http(char *headers[], char *body, bool spool)
         const char *cert_file = get_cainfo_config();
         const char *tid_header = get_tidheader_config();
 
+        // Initialize the libcurl global environment once per POST. This lets us
+        // clean up the environment after each POST so that when the daemon is
+        // sitting idle, it will be consuming as little memory as possible.
+        curl_global_init(CURL_GLOBAL_ALL);
+
         curl = curl_easy_init();
         if (!curl) {
                 telem_log(LOG_ERR, "curl_easy_init(): Unable to start libcurl"
@@ -532,6 +537,9 @@ bool post_record_http(char *headers[], char *body, bool spool)
 
         curl_slist_free_all(custom_headers);
         curl_easy_cleanup(curl);
+
+        curl_global_cleanup();
+
         return res ? false : true;
 }
 


### PR DESCRIPTION
When the daemon is sitting idle, we are seeing libcurl consume around
2MB of memory, which had been previously allocated on-the-fly for its
global environment.

To have more control over this memory consumption, making sure the
daemon uses as little memory as possible when doing no work, explicitly
allocate the libcurl global environment before each POST and deallocate
it afterwards.