### PR TITLE
crash probe: keep core files under certain conditions

### DIFF
--- a/src/probes/crash_probe.c
+++ b/src/probes/crash_probe.c
@@ -699,6 +699,8 @@ fail:
                 close(core_fd);
         }
 
+        // Remove the core file by default, except when the --core-file option
+        // is specified, or when keep_core is overridden to true.
         if (!core_file && !keep_core) {
                 unlink(temp_core);
         }

--- a/src/probes/crash_probe.c
+++ b/src/probes/crash_probe.c
@@ -666,6 +666,11 @@ success:
 
         ret = EXIT_SUCCESS;
 fail:
+        // Do not remove the core file if any errors occur
+        if (ret == EXIT_FAILURE) {
+                keep_core = true;
+        }
+
         free(core_file);
         free(proc_name);
         free(proc_path);


### PR DESCRIPTION
When the path filters for privacy are in effect, backtraces are scrubbed from records, and this results in the core files being unlinked.

However, this is not friendly behavior for the developer. A common situation that triggers the path filters is installing custom binaries on the system (say, under /usr/local/bin or /opt/bin) for testing purposes. To better enable developers to debug their programs, having the core files available to process with gdb is very valuable.

Eventually, I would like to add an opt-in to keep all core files, but I'll wait until the configuration code is refactored.