### PR TITLE
Fix regression in configuration parsing

### DIFF
--- a/src/configuration.c
+++ b/src/configuration.c
@@ -105,6 +105,7 @@ bool read_config_from_file(char *config_file, struct configuration *config)
                                         return false;
                                 }
                         } else {
+                                fprintf(stderr, "ERR: missing key with string value: %s\n", config_key_str[i]);
                                 return false;
                         }
                 }
@@ -114,6 +115,7 @@ bool read_config_from_file(char *config_file, struct configuration *config)
                         if (ptr) {
                                 config->intValues[i] = strtoll(ptr, NULL, 10);
                         } else {
+                                fprintf(stderr, "ERR: missing key with integer value: %s\n", config_key_int[i]);
                                 return false;
                         }
                 }
@@ -131,6 +133,7 @@ bool read_config_from_file(char *config_file, struct configuration *config)
                                         config->boolValues[i] = true;
                                 }
                         } else {
+                                fprintf(stderr, "ERR: missing key with boolean value: %s\n", config_key_bool[i]);
                                 return false;
                         }
                 }

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -97,8 +97,14 @@ bool read_config_from_file(char *config_file, struct configuration *config)
                 return false;
         } else {
                 for (int i = CONF_STR_MIN + 1; i < CONF_STR_MAX; i++) {
-                        config->strValues[i] = strdup(nc_hashmap_get(nc_hashmap_get(keyfile, "settings"), config_key_str[i]));
-                        if (config->strValues[i] == NULL) {
+                        char *ptr;
+                        ptr = nc_hashmap_get(nc_hashmap_get(keyfile, "settings"), config_key_str[i]);
+                        if (ptr) {
+                                config->strValues[i] = strdup(ptr);
+                                if (config->strValues[i] == NULL) {
+                                        return false;
+                                }
+                        } else {
                                 return false;
                         }
                 }


### PR DESCRIPTION
There was a regression introduced in the port to libnica that resulted in a segfault. Fix that issue, and make the error reporting more verbose and thus more actionable.