### PR TITLE
Additional metadata from client

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -33,7 +33,10 @@ static const char *header_names[] = {
         TM_SYSTEM_BUILD_STR,
         TM_KERNEL_VERSION_STR,
         TM_PAYLOAD_VERSION_STR,
-        TM_SYSTEM_NAME_STR
+        TM_SYSTEM_NAME_STR,
+        TM_BOARD_NAME_STR,
+        TM_CPU_MODEL_STR,
+        TM_BIOS_VERSION_STR
 };
 
 const char *get_header_name(int ind)

--- a/src/common.h
+++ b/src/common.h
@@ -35,6 +35,10 @@
 #define TM_KERNEL_VERSION 8
 #define TM_PAYLOAD_VERSION 9
 #define TM_SYSTEM_NAME 10
+#define TM_BOARD_NAME 11
+#define TM_CPU_MODEL 12
+#define TM_BIOS_VERSION 13
+
 
 #define TM_RECORD_VERSION_STR "record_format_version"
 #define TM_CLASSIFICATION_STR "classification"
@@ -47,8 +51,11 @@
 #define TM_KERNEL_VERSION_STR "kernel_version"
 #define TM_PAYLOAD_VERSION_STR "payload_format_version"
 #define TM_SYSTEM_NAME_STR "system_name"
+#define TM_BOARD_NAME_STR "board_name"
+#define TM_CPU_MODEL_STR "cpu_model"
+#define TM_BIOS_VERSION_STR "bios_version"
 
-#define NUM_HEADERS 11
+#define NUM_HEADERS 14
 
 /* For internal library usage. Bump the version whenever we change the record
  * structure (e.g. adding or removing a header field). Note that the value

--- a/src/telemetry.c
+++ b/src/telemetry.c
@@ -416,8 +416,8 @@ static int set_cpu_model_header(struct telem_ref *t_ref)
         char *model_name = NULL;
         const char *attr_name = "model name";
         int status = 0;
-        size_t attr_len = sizeof(attr_name);
-        size_t size = 0;
+        size_t attr_len = strlen(attr_name);
+        size_t model_str_len = 0;
 
         fs = fopen("/proc/cpuinfo", "r");
         if (fs != NULL) {
@@ -427,27 +427,26 @@ static int set_cpu_model_header(struct telem_ref *t_ref)
                             break;
                         }
                 }
-		fclose(fs);
-		if (model_name != NULL) {
-		        puts("HELLO");	
-                	size = strlen(model_name);
-                	if (size > 2) {
-                    		model_name = (char *) model_name + 2 * sizeof(char);
-                        }
-			size = strlen(model_name);
-			(model_name)[size - 1] = '\0';
-                        status = set_header(
+                fclose(fs);
+                if (model_name != NULL) {
+                            model_str_len = strlen(model_name);
+                            if (model_str_len > 2) {
+                                    model_name = (char *) model_name + 2 * sizeof(char);
+                                    model_name[model_str_len - 2] = '\0';
+                            } else {
+                                    model_name = "blank";
+                            }
+                } else {
+                        model_name = "blank";
+                        fprintf(stderr, "NOTICE: Unable to find attribute:%s\n", attr_name);
+                }
+
+                status = set_header(
                                 &(t_ref->record->headers[TM_CPU_MODEL]),
                                 TM_CPU_MODEL_STR, model_name,
-                                &(t_ref->record->header_size));			
-
-		} else {
-			fprintf(stderr, "NOTICE: Unable to find attribute:%s\n", attr_name);
-                        status = set_header(
-                                &(t_ref->record->headers[TM_CPU_MODEL]),
-                                TM_CPU_MODEL_STR, "blank",
                                 &(t_ref->record->header_size));
-		}
+
+
         } else {
 #ifdef DEBUG
                 fprint(stderr, "NOTICE: Unable to open /proc/cpuinfo\n");

--- a/tests/check_daemon.c
+++ b/tests/check_daemon.c
@@ -295,7 +295,10 @@ START_TEST(check_process_record_with_correct_size_and_data)
                         "machine_id: 1234\ncreation_timestamp: 1418672344\narch:x86_64\n"
                         "host_type: macbookpro\nbuild: 200\nkernel_version: 3.15\n"
                         "payload_format_version: 1\n"
-                        "system_name: clear-linux-os\n";
+                        "system_name: clear-linux-os\n"
+                        "board_name: Qemu|Intel\n"
+                        "cpu_model: Intel(R) Core(TM) i7-5650U CPU @ 2.20GHz\n"
+                        "bios_version: Qemu\n";
         char *post_body = "test message";
 
         set_up_socket_pair(&client_fd, &server_fd);


### PR DESCRIPTION
 Additional headers added: board_name, cpu_model, and bios_version.

    * Board name is a combination of board_name and board_vendor from
    dmi file system.

    * CPU model is read from /proc/cpuinfo.

    * BIOS version is taken from dmi file system.