### PR TITLE
Fix build issues when -DDEBUG is enabled

### DIFF
--- a/src/configuration.c
+++ b/src/configuration.c
@@ -91,8 +91,7 @@ bool read_config_from_file(char *config_file, struct configuration *config)
         keyfile = nc_ini_file_parse(config_file);
         if (!keyfile) {
 #ifdef DEBUG
-                fprintf(stderr, "ERR: Failed to read config file: %s\n",
-                        error->message);
+                fprintf(stderr, "ERR: Failed to read config file\n");
 #endif
                 return false;
         } else {

--- a/src/telemetry.c
+++ b/src/telemetry.c
@@ -448,7 +448,7 @@ static int set_cpu_model_header(struct telem_ref *t_ref)
 
         } else {
 #ifdef DEBUG
-                fprint(stderr, "NOTICE: Unable to open /proc/cpuinfo\n");
+                fprintf(stderr, "NOTICE: Unable to open /proc/cpuinfo\n");
 #endif
                 status = -1;
         }


### PR DESCRIPTION
The call to "fprint()" is a typo and should be "fprintf()".

Also, the "error->message" string is an artifact from the time when
telemetrics-client used glib. Now it uses libnica, which propogates
errors differently. Simply remove the format specifier for now.