### PR TITLE
Restart on update

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -93,17 +93,15 @@ test -z "${tmpfilespath}" && tmpfilespath=/usr/lib/tmpfiles.d
 AC_SUBST(SYSTEMD_TMPFILESDIR, [${tmpfilespath}])
 
 AC_ARG_WITH([systemdsysctldir], AS_HELP_STRING([--with-systemdsysctldir=DIR],
-	    [path to systemd sysctl dir @<:@default=/usr/lib/sysctl.d@:>@]), [sysctlpath=${withval}])
+            [path to systemd sysctl dir @<:@default=/usr/lib/sysctl.d@:>@]), [sysctlpath=${withval}],
+            [sysctlpath="$($PKG_CONFIG --variable=sysctldir systemd)"])
 test -z "${sysctlpath}" && sysctlpath=/usr/lib/sysctl.d
 AC_SUBST(SYSTEMD_SYSCTLDIR, [${sysctlpath}])
 
-
 AC_ARG_WITH([systemdsystemctldir], AS_HELP_STRING([--with-systemdsystemctldir=DIR],
-            [path to systemd systemctl dir @<:@default=/usr/bin@:>@]), [systemctlpath=${withval}],
-            [systemctlpath="$($PKG_CONFIG --variable=systemctldir systemd)"])
+            [path to systemd systemctl dir @<:@default=/usr/bin@:>@]), [systemctlpath=${withval}])
 test -z "${systemctlpath}" && systemctlpath=/usr/bin
 AC_SUBST(SYSTEMD_SYSTEMCTLDIR, [${systemctlpath}])
-
 
 # systemd.pc gives the /etc conf dir, so we can't use PKG_CONFIG for this one
 AC_ARG_WITH([systemdsystemconfdir], AS_HELP_STRING([--with-systemdsystemconfdir=DIR],

--- a/configure.ac
+++ b/configure.ac
@@ -93,8 +93,8 @@ test -z "${tmpfilespath}" && tmpfilespath=/usr/lib/tmpfiles.d
 AC_SUBST(SYSTEMD_TMPFILESDIR, [${tmpfilespath}])
 
 AC_ARG_WITH([systemdsysctldir], AS_HELP_STRING([--with-systemdsysctldir=DIR],
-            [path to systemd sysctl dir @<:@default=/usr/lib/sysctl.d@:>@]), [sysctlpath=${withval}],
-            [sysctlpath="$($PKG_CONFIG --variable=sysctldir systemd)"])
+	    [path to systemd sysctl dir @<:@default=/usr/lib/sysctl.d@:>@]), [sysctlpath=${withval}],
+	    [sysctlpath="$($PKG_CONFIG --variable=sysctldir systemd)"])
 test -z "${sysctlpath}" && sysctlpath=/usr/lib/sysctl.d
 AC_SUBST(SYSTEMD_SYSCTLDIR, [${sysctlpath}])
 

--- a/configure.ac
+++ b/configure.ac
@@ -93,10 +93,17 @@ test -z "${tmpfilespath}" && tmpfilespath=/usr/lib/tmpfiles.d
 AC_SUBST(SYSTEMD_TMPFILESDIR, [${tmpfilespath}])
 
 AC_ARG_WITH([systemdsysctldir], AS_HELP_STRING([--with-systemdsysctldir=DIR],
-	    [path to systemd sysctl dir @<:@default=/usr/lib/sysctl.d@:>@]), [sysctlpath=${withval}],
-	    [sysctlpath="$($PKG_CONFIG --variable=sysctldir systemd)"])
+	    [path to systemd sysctl dir @<:@default=/usr/lib/sysctl.d@:>@]), [sysctlpath=${withval}])
 test -z "${sysctlpath}" && sysctlpath=/usr/lib/sysctl.d
 AC_SUBST(SYSTEMD_SYSCTLDIR, [${sysctlpath}])
+
+
+AC_ARG_WITH([systemdsystemctldir], AS_HELP_STRING([--with-systemdsystemctldir=DIR],
+            [path to systemd systemctl dir @<:@default=/usr/bin@:>@]), [systemctlpath=${withval}],
+            [systemctlpath="$($PKG_CONFIG --variable=systemctldir systemd)"])
+test -z "${systemctlpath}" && systemctlpath=/usr/bin
+AC_SUBST(SYSTEMD_SYSTEMCTLDIR, [${systemctlpath}])
+
 
 # systemd.pc gives the /etc conf dir, so we can't use PKG_CONFIG for this one
 AC_ARG_WITH([systemdsystemconfdir], AS_HELP_STRING([--with-systemdsystemconfdir=DIR],

--- a/src/data/local.mk
+++ b/src/data/local.mk
@@ -4,7 +4,8 @@ pathfix = @sed \
 	-e 's|@libdir[@]|$(libdir)|g' \
 	-e 's|@localstatedir[@]|$(localstatedir)|g' \
 	-e 's|@PACKAGE_VERSION[@]|$(PACKAGE_VERSION)|g' \
-	-e 's|@SOCKETDIR[@]|$(SOCKETDIR)|g'
+	-e 's|@SOCKETDIR[@]|$(SOCKETDIR)|g' \
+	-e 's|@systemctldir[@]|$(SYSTEMD_SYSTEMCTLDIR)|g'
 
 EXTRA_DIST += \
 	%D%/40-core-ulimit.conf \
@@ -21,6 +22,7 @@ EXTRA_DIST += \
 	%D%/telemd.path.in \
 	%D%/telemd.service.in \
 	%D%/telemd.socket.in \
+	%D%/telemd-update-trigger.service.in \
 	%D%/telemetrics-dirs.conf.in \
 	%D%/telemetrics.conf.in
 
@@ -53,6 +55,7 @@ systemdunit_DATA = \
 	%D%/pstore-clean.service \
 	%D%/telemd.service \
 	%D%/telemd.socket \
+	%D%/telemd-update-trigger.service \
 	%D%/telemd.path
 
 %D%/hprobe.service: %D%/hprobe.service.in
@@ -82,6 +85,9 @@ systemdunit_DATA = \
 %D%/telemd.path: %D%/telemd.path.in
 	$(pathfix) < $< > $@
 
+%D%/telemd-update-trigger.service: %D%/telemd-update-trigger.service.in
+	$(pathfix) < $< > $@
+
 sysctldir = @SYSTEMD_SYSCTLDIR@
 sysctl_DATA = %D%/40-crash-probe.conf
 
@@ -95,6 +101,7 @@ clean-local:
 	-rm -f  %D%/telemd.service \
 		%D%/telemd.socket \
 		%D%/telemd.path \
+		%D%/telemd-update-trigger.service \
 		%D%/telemetrics.conf \
 		%D%/telemetrics-dirs.conf \
 		%D%/libtelemetry.pc \

--- a/src/data/telemd-update-trigger.service.in
+++ b/src/data/telemd-update-trigger.service.in
@@ -1,0 +1,7 @@
+[Unit]
+Description=Restart Telemetrics Daemon On Update
+BindsTo=update-triggers.target
+
+[Service]
+Type=oneshot
+ExecStart=@systemctldir@/systemctl try-restart telemd.service


### PR DESCRIPTION
Because telemd does not restart when an update is installed the daemon could get out of sync with probes if a new version of a probe requires a new version of telemd. This change will trigger a restart when an update takes place.