### PR TITLE
Fix compiler warning

### DIFF
--- a/src/telemdaemon.c
+++ b/src/telemdaemon.c
@@ -27,6 +27,7 @@
 #include <fcntl.h>
 #include <time.h>
 #include <malloc.h>
+#include <sys/uio.h>
 
 #include "telemdaemon.h"
 #include "common.h"


### PR DESCRIPTION
`readv` is declared in <sys/uio.h>