### PR TITLE
Fixing config parameter in hprobe

### DIFF
--- a/src/probes/hello.c
+++ b/src/probes/hello.c
@@ -49,7 +49,7 @@ int main(int argc, char **argv)
         int ret = 0;
 
         struct option opts[] = {
-                { "cfile", 1, NULL, 'f' },
+                { "config_file", 1, NULL, 'f' },
                 { "heartbeat", 0, NULL, 'H' },
                 { "help", 0, NULL, 'h' },
                 { "version", 0, NULL, 'V' },


### PR DESCRIPTION
Parameter config_file is named incorrectly in opts array.
