### PR TITLE
Changes to compile check_libtelemetry with flto

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([telemetrics-client], [1.16.1], [https://clearlinux.org/])
+AC_INIT([telemetrics-client], [1.16.2], [https://clearlinux.org/])
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([1.14 -Wall -Werror -Wno-extra-portability foreign subdir-objects])
 AM_SILENT_RULES([yes])

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -131,7 +131,6 @@ EXTRA_DIST += \
 
 %C%_check_journal_SOURCES = \
 	%D%/check_journal.c \
-	src/journal/journal.h \
 	src/journal/journal.c \
 	src/util.h \
 	src/util.c
@@ -145,7 +144,10 @@ EXTRA_DIST += \
 
 %C%_check_libtelemetry_SOURCES = \
 	%D%/check_libtelemetry.c \
-	src/telemetry.c
+	src/configuration.h \
+	src/util.h \
+	src/nica/hashmap.h \
+	src/nica/inifile.h
 
 %C%_check_libtelemetry_CFLAGS = \
 	$(AM_CFLAGS) \


### PR DESCRIPTION
Added source files references to local.mk and headers files
to check_libtelemetry to compile client in gcc 8 and CFLAGS
-flto. This change fixes an error when compiling and running
tests where the resulting binary is unable to find symbols.

This is a workaround and has to be fixed properly.

Signed-off-by: Alex Jaramillo <alex.v.jaramillo@intel.com>