### PR TITLE
v1.16.3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([telemetrics-client], [1.16.2], [https://clearlinux.org/])
+AC_INIT([telemetrics-client], [1.16.3], [https://clearlinux.org/])
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([1.14 -Wall -Werror -Wno-extra-portability foreign subdir-objects])
 AM_SILENT_RULES([yes])

--- a/src/data/40-crash-probe.conf.in
+++ b/src/data/40-crash-probe.conf.in
@@ -1,1 +1,0 @@
-kernel.core_pattern = |@bindir@/crashprobe -p %e -E %E -s %s

--- a/src/data/local.mk
+++ b/src/data/local.mk
@@ -9,7 +9,6 @@ pathfix = @sed \
 
 EXTRA_DIST += \
 	%D%/40-core-ulimit.conf \
-	%D%/40-crash-probe.conf.in \
 	%D%/example.conf \
 	%D%/example.1.conf \
 	%D%/hprobe.service.in \
@@ -94,12 +93,6 @@ systemdunit_DATA = \
 %D%/telemd-update-trigger.service: %D%/telemd-update-trigger.service.in
 	$(pathfix) < $< > $@
 
-sysctldir = @SYSTEMD_SYSCTLDIR@
-sysctl_DATA = %D%/40-crash-probe.conf
-
-%D%/40-crash-probe.conf: %D%/40-crash-probe.conf.in
-	$(pathfix) < $< > $@
-
 systemconfdir = @SYSTEMD_SYSTEMCONFDIR@
 systemconf_DATA = %D%/40-core-ulimit.conf
 
@@ -111,7 +104,6 @@ clean-local:
 		%D%/telemetrics.conf \
 		%D%/telemetrics-dirs.conf \
 		%D%/libtelemetry.pc \
-		%D%/40-crash-probe.conf \
 		%D%/journal-probe.service \
 		%D%/oops-probe.service \
 		%D%/pstore-probe.service \


### PR DESCRIPTION
This release removes the crash probe exclusive use of the core dump
reported by the kernel. Other component above telemetry will handle
this to properly report core dumps to telemetry (when available).

Signed-off-by: Alex Jaramillo <alex.v.jaramillo@intel.com>