### PR TITLE
Revert "Removing crash dump configuration"

### DIFF
--- a/src/data/40-crash-probe.conf.in
+++ b/src/data/40-crash-probe.conf.in
@@ -1,0 +1,1 @@
+kernel.core_pattern = |@bindir@/crashprobe -p %e -E %E -s %s

--- a/src/data/local.mk
+++ b/src/data/local.mk
@@ -9,6 +9,7 @@ pathfix = @sed \
 
 EXTRA_DIST += \
 	%D%/40-core-ulimit.conf \
+	%D%/40-crash-probe.conf.in \
 	%D%/example.conf \
 	%D%/example.1.conf \
 	%D%/hprobe.service.in \
@@ -93,6 +94,12 @@ systemdunit_DATA = \
 %D%/telemd-update-trigger.service: %D%/telemd-update-trigger.service.in
 	$(pathfix) < $< > $@
 
+sysctldir = @SYSTEMD_SYSCTLDIR@
+sysctl_DATA = %D%/40-crash-probe.conf
+
+%D%/40-crash-probe.conf: %D%/40-crash-probe.conf.in
+	$(pathfix) < $< > $@
+
 systemconfdir = @SYSTEMD_SYSTEMCONFDIR@
 systemconf_DATA = %D%/40-core-ulimit.conf
 
@@ -104,6 +111,7 @@ clean-local:
 		%D%/telemetrics.conf \
 		%D%/telemetrics-dirs.conf \
 		%D%/libtelemetry.pc \
+		%D%/40-crash-probe.conf \
 		%D%/journal-probe.service \
 		%D%/oops-probe.service \
 		%D%/pstore-probe.service \


### PR DESCRIPTION
Installing a crashprobe sysctl conf file by default is, in my opinion, the most useful way to enable the crashprobe for Linux distributions.

The fact that Clear Linux does not use it anymore does not necessarily dictate policy for telemetrics-client itself. My preference would be to simply exclude the conf file in the Clear Linux telemetrics-client
package, since that is very easy to do with autospec. Also, the new crash handling implementation in Clear Linux requires a systemd patch that won't be upstreamed, so this is another good reason to install the conf by default.

This reverts commit d1425173a9fa29a643c2eb0a32a7b73869dcf978.