### PR TITLE
Improvements and fixes to telem-record-gen

### DIFF
--- a/src/probes/telem_record_gen.c
+++ b/src/probes/telem_record_gen.c
@@ -373,7 +373,7 @@ out:
 
 int print_record(char *payload)
 {
-        struct telem_ref *t_ref;
+        struct telem_ref *t_ref = NULL;
         int ret = 0;
         int i = 0;
 
@@ -381,9 +381,9 @@ int print_record(char *payload)
                 for (i = 0; i < NUM_HEADERS; i++) {
                         fprintf(stdout, "%s", t_ref->record->headers[i]);
                 }
+                fprintf(stdout, "%s\n", t_ref->record->payload);
+                tm_free_record(t_ref);
         }
-        fprintf(stdout, "%s\n", t_ref->record->payload);
-        tm_free_record(t_ref);
 
         return ret;
 }

--- a/src/probes/telem_record_gen.c
+++ b/src/probes/telem_record_gen.c
@@ -415,6 +415,7 @@ fail:
         free(opt_class);
         free(opt_payload);
         free(opt_event_id);
+        free(payload);
 
         return ret;
 }

--- a/src/telemetry.c
+++ b/src/telemetry.c
@@ -410,7 +410,7 @@ static int set_cpu_model_header(struct telem_ref *t_ref)
                         model_str_len = strlen(model_name);
                         if (model_str_len > 2) {
                                 model_name = (char *)model_name + 2 * sizeof(char);
-                                model_name[model_str_len - 2] = '\0';
+                                model_name[model_str_len - 3] = '\0';
                         } else {
                                 model_name = "blank";
                         }


### PR DESCRIPTION
Multiple improvements and fixes to telem record gen probe.
* Adding a print option to telem-record-gen to print metadata and record payload. Additionally remove option that is not implemented.
* Fixing detected memory leak.
* Remove return carriage that should not be present in model name header.