### PR TITLE
Spool: retry more often if there's work to do

### DIFF
--- a/src/spool.c
+++ b/src/spool.c
@@ -81,7 +81,10 @@ long get_spool_dir_size()
         return dir_size;
 }
 
-void spool_records_loop(long *current_spool_size)
+/*
+ * Returns the number of remaining unsent records
+ */
+int spool_records_loop(long *current_spool_size)
 {
         const char *spool_dir_path;
         int numentries;
@@ -94,10 +97,10 @@ void spool_records_loop(long *current_spool_size)
 
         if (numentries == 0) {
                 telem_log(LOG_DEBUG, "No entries in spool\n");
-                return;
+                return numentries;
         } else if (numentries < 0) {
                 telem_perror("Error while scanning spool");
-                return;
+                return 0;
         }
 
         qsort_r(namelist, (size_t)numentries, sizeof(struct dirent *),
@@ -125,6 +128,8 @@ void spool_records_loop(long *current_spool_size)
                 free(namelist[i]);
         }
         free(namelist);
+
+        return records_sent - numentries;
 }
 
 void process_spooled_record(const char *spool_dir, char *name,

--- a/src/spool.h
+++ b/src/spool.h
@@ -19,7 +19,7 @@
 /**
  * Run the spool record loop periodically
  */
-void spool_records_loop(long *current_spool_size);
+int spool_records_loop(long *current_spool_size);
 
 /**
  * Process the spooled record


### PR DESCRIPTION
The spool error retry time is set to 900s by default, which
means that in any spool error case, the system will wait 15
minutes before trying to deliver a single record again.

This causes us to lose a lot of telemetry because (1) telemetry
ends up starting before networking is active and (2) the system
shuts down after a few minutes already, never making it to the
full 15 minute mark.

This change adds a throttle that automatically extends the time
between delivery attempts when the spool isn't empty and a
delivery error occurs. It simply retries the delivery after 1, 2,
4, 8, etc. seconds up to 256 until the spool either delivers all
the entries, or until the throttle end.

This makes the 900s retry time mostly useless, in effect.