### PR TITLE
Fix telem-record-gen bug in send_record condition

### DIFF
--- a/src/probes/telem_record_gen.c
+++ b/src/probes/telem_record_gen.c
@@ -409,7 +409,7 @@ int main(int argc, char **argv)
                 print_record(payload);
         }
 
-        if (opt_nopost == false && !send_record(payload)) {
+        if (opt_nopost == false && send_record(payload) != 0) {
                 goto fail;
         }
 


### PR DESCRIPTION
This change fixes a bug where the telem-record-gen probe returns 1
though the execution of the probe was successful. This bug was
introduced when print message option feature was implemented.

Signed-off-by: Alex Jaramillo <alex.v.jaramillo@intel.com>