### PR TITLE
Post retry when not network available at boot

### DIFF
--- a/src/telempostdaemon.h
+++ b/src/telempostdaemon.h
@@ -19,6 +19,7 @@
 #define NFDS 2
 #define TM_RATE_LIMIT_SLOTS (1 /*h*/ * 60 /*m*/)
 #define TM_RECORD_COUNTER (1)
+#define MAX_RETRY_ATTEMPTS 8
 
 #include <poll.h>
 #include <stdbool.h>
@@ -83,17 +84,20 @@ void close_daemon(TelemPostDaemon *daemon);
  * Processed record written on disk
  *
  * @param filename a pointor to record on disk
+ * @param is_retry a boolean value that indicates if
+ *        the record has been previously processed.
  * @param daemon post to telemetry post daemon
  */
-bool process_staged_record(char *filename, TelemPostDaemon *daemon);
+bool process_staged_record(char *filename, bool is_retry, TelemPostDaemon *daemon);
 
 /**
  * Scans staging directory to process files that were
  * missed by file watcher
  *
  * @param daemon a pointer to telemetry post daemon
+ * @return the number of records that were removed from spool
  */
-void staging_records_loop(TelemPostDaemon *daemon);
+int staging_records_loop(TelemPostDaemon *daemon);
 
 /**
  * Posts a record to backend

--- a/tests/check_postd.c
+++ b/tests/check_postd.c
@@ -62,7 +62,7 @@ START_TEST(check_handle_client_with_no_data)
         bool success;
         char *filename = ABSTOPSRCDIR "/tests/telempostd/empty_message";
 
-        success = process_staged_record(filename, &tdaemon);
+        success = process_staged_record(filename, false, &tdaemon);
         // Return true to remove corrupted record
         ck_assert(success == true);
 }
@@ -75,7 +75,7 @@ START_TEST(check_handle_client_with_incorrect_data)
         bool success;
         char *filename = ABSTOPSRCDIR "/tests/telempostd/incorrect_message";
 
-        success = process_staged_record(filename, &tdaemon);
+        success = process_staged_record(filename, false, &tdaemon);
         // Return true to remove corrupted record
         ck_assert(success == true);
 }
@@ -88,7 +88,7 @@ START_TEST(check_process_record_with_correct_size_and_data)
         bool success;
         char *filename = ABSTOPSRCDIR "/tests/telempostd/correct_message";
 
-        success = process_staged_record(filename, &tdaemon);
+        success = process_staged_record(filename, false, &tdaemon);
         ck_assert(success == true);
 }
 END_TEST
@@ -100,7 +100,7 @@ START_TEST(check_process_record_with_incorrect_headers)
         bool success;
         char *filename = ABSTOPSRCDIR "/tests/telempostd/incorrect_headers";
 
-        success = process_staged_record(filename, &tdaemon);
+        success = process_staged_record(filename, false, &tdaemon);
         // Return true to remove corrupted record
         ck_assert(success == true);
 }


### PR DESCRIPTION
The following changes are:
* Logic to retry sending telemetry messages when during boot network was not available.
* Moving block of code in telempostdaemon to logically related branch.

This PR is partially a port of [PR/72](https://github.com/clearlinux/telemetrics-client/pull/72) due to refactoring PR/72 was not longer applicable.