### PR TITLE
probes/telem_record_gen.c: fix possible segfault in print_record

### DIFF
--- a/src/probes/telem_record_gen.c
+++ b/src/probes/telem_record_gen.c
@@ -377,7 +377,7 @@ int print_record(char *payload)
         int ret = 0;
         int i = 0;
 
-        if ((ret = instanciate_record(&t_ref, payload)) != -1) {
+        if ((ret = instanciate_record(&t_ref, payload)) == 0) {
                 for (i = 0; i < NUM_HEADERS; i++) {
                         fprintf(stdout, "%s", t_ref->record->headers[i]);
                 }


### PR DESCRIPTION
When opt-out is enabled, the instanciate_record() function will return
-111 and the headers will not be allocated. Since print_record only
checks that instanciate_record does not return -1 before trying to go
through the headers, a segfault will occur.

This can be seen via:
$ sudo touch /etc/telemetrics/opt-out
$ telem-record-gen -c a/b/c -o -n -p 'payload goes here'

Signed-off-by: California Sullivan <california.l.sullivan@intel.com>