### PR TITLE
Remove redundant definition MAX_PAYLOAD_SIZE

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -78,16 +78,13 @@ static const uint32_t RECORD_FORMAT_VERSION = 4;
 #define TM_OPT_OUT_FILE "/etc/telemetrics/opt-out"
 
 /* Currently max supported payload size is 8kb */
-#define MAX_PAYLOAD_SIZE 8192
+#define MAX_PAYLOAD_LENGTH 8192
 
 /* Maximum size for a category string is 122 bytes */
 #define MAX_CLASS_LENGTH 122
 
 /* Maximum size for a sub category 40 bytes */
 #define MAX_SUBCAT_LENGTH 40
-
-/* Max Payload size is 8 kibabytes (8192) */
-#define MAX_PAYLOAD_LENGTH 8192
 
 /* SPOOL DEFINES */
 /* Spooling should run every TM_SPOOL_RUN_MAX atleast */

--- a/src/probes/bert_probe.c
+++ b/src/probes/bert_probe.c
@@ -43,13 +43,13 @@ static int allocate_payload_buffer(char **payload)
 {
         int ret = 0;
 
-        *payload = (char *)malloc(MAX_PAYLOAD_SIZE);
+        *payload = (char *)malloc(MAX_PAYLOAD_LENGTH);
 
         if (*payload == NULL) {
                 goto out;
         }
 
-        *payload = memset(*payload, 0, MAX_PAYLOAD_SIZE);
+        *payload = memset(*payload, 0, MAX_PAYLOAD_LENGTH);
         ret = 1;
 
 out:
@@ -108,7 +108,7 @@ int main(int argc, char **argv)
                 goto fail;
         }
 
-        if (!(ret = nc_b64enc_filename(bert_record_file, payload, MAX_PAYLOAD_SIZE))) {
+        if (!(ret = nc_b64enc_filename(bert_record_file, payload, MAX_PAYLOAD_LENGTH))) {
                 printf("Failed to read payload from: %s\n", bert_record_file);
                 goto fail;
         }

--- a/src/probes/telem_record_gen.c
+++ b/src/probes/telem_record_gen.c
@@ -228,13 +228,13 @@ int allocate_payload_buffer(char **payload)
 {
         int ret = 0;
 
-        *payload = (char *)malloc(MAX_PAYLOAD_SIZE);
+        *payload = (char *)malloc(MAX_PAYLOAD_LENGTH);
 
         if (*payload == NULL) {
                 goto out1;
         }
 
-        *payload = memset(*payload, 0, MAX_PAYLOAD_SIZE);
+        *payload = memset(*payload, 0, MAX_PAYLOAD_LENGTH);
         ret = 1;
 
 out1:
@@ -256,7 +256,7 @@ int get_payload_from_file(char **payload)
         }
 
         bytes_in = fread(*payload, 1,
-                         MAX_PAYLOAD_SIZE - 1, fp);
+                         MAX_PAYLOAD_LENGTH - 1, fp);
 
         /* if fread fails */
         if (bytes_in == 0 && ferror(fp) != 0) {
@@ -277,8 +277,8 @@ void get_payload_from_opt(char **payload)
         size_t len = 0;
 
         len = strlen(opt_payload);
-        if (len >= MAX_PAYLOAD_SIZE) {
-                len = MAX_PAYLOAD_SIZE - 1;
+        if (len >= MAX_PAYLOAD_LENGTH) {
+                len = MAX_PAYLOAD_LENGTH - 1;
         }
         strncpy(*payload, opt_payload, len);
 }
@@ -288,9 +288,9 @@ void get_payload_from_stdin(char **payload)
         size_t bytes_in = 0;
         int c;
 
-        bytes_in = fread(*payload, 1, MAX_PAYLOAD_SIZE - 1, stdin);
+        bytes_in = fread(*payload, 1, MAX_PAYLOAD_LENGTH - 1, stdin);
 
-        if (bytes_in == MAX_PAYLOAD_SIZE - 1) {
+        if (bytes_in == MAX_PAYLOAD_LENGTH - 1) {
                 /* Throw away the rest of stdin */
                 while (EOF != (c = fgetc(stdin))) {
                         continue;


### PR DESCRIPTION
The file common.h contained two definitions to specify the
maximum allowable payload:

define MAX_PAYLOAD_SIZE 8192
define MAX_PAYLOAD_LENGTH 8192

This patch removes the definition for MAX_PAYLOAD_SIZE and replaces all
occurences of MAX_PAYLOAD_SIZE with MAX_PAYLOAD_LENGTH.

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>