### PR TITLE
Update docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,9 @@
 
 ## Notes on manual pages
 
-The manual pages are generated using `ronn(1)`. To recreate them,
-run `make manpages` in the toplevel  folder. If you want to edit
-the documentation for upstream changes, make sure to edit the `*.md`
+The manual pages are generated using `rst2man.py`. To recreate them,
+run `make manpages` in the toplevel folder. If you want to edit
+the documentation for upstream changes, make sure to edit the `*.rst`
 files and not the shipped nroff output files.
 
 


### PR DESCRIPTION
We switched from .md files to .rst files a while ago in v1.11.1.
Since then we genarate man pages using 'rst2man.py', hence the README.md
file needs to be modified to reflect this change.
(/usr/bin/ronn is actually not even availabel in CLR anymore)

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>