### PR TITLE
bert_probe.c: remove unsupported cmdline option

### DIFF
--- a/src/probes/bert_probe.c
+++ b/src/probes/bert_probe.c
@@ -75,7 +75,7 @@ int main(int argc, char **argv)
                 { NULL, 0, NULL, 0 }
         };
 
-        while ((c = getopt_long(argc, argv, "f:hHV", opts, &opt_index)) != -1) {
+        while ((c = getopt_long(argc, argv, "f:hV", opts, &opt_index)) != -1) {
                 switch (c) {
                         case 'f':
                                 if (asprintf(&cfile, "%s", (char *)optarg) < 0) {


### PR DESCRIPTION
There is no entry for 'H' command line option, yet the
getopt_long accepts it as a valid option.

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>