### PR TITLE
Fix for missing restart units

### DIFF
--- a/scripts/telemctl
+++ b/scripts/telemctl
@@ -4,14 +4,14 @@ declare -a SPECIAL_UNITS=(
   hprobe.timer
   telemprobd.socket
   telempostd.path
+  klogscanner.service
+  oops-probe.service
+  journal-probe.service
 )
 
 declare -a SERVICES=(
   hprobe.service
-  journal-probe.service
-  oops-probe.service
   pstore-probe.service
-  klogscanner.service
   telemprobd.service
   telempostd.service
 )


### PR DESCRIPTION
This change fixes a bug where the oops probe and journal probe are not
restarted when telemctl restart is executed.

Signed-off-by: Alex Jaramillo <alex.v.jaramillo@intel.com>