### PR TITLE
tm_set_config_file: return status and call from all probes

### DIFF
--- a/docs/man/telemetry.3
+++ b/docs/man/telemetry.3
@@ -44,7 +44,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .sp
 \fBvoid tm_free_record(struct telem_ref *t_ref)\fP
 .sp
-\fBvoid tm_set_config_file(char *c_file)\fP
+\fBint tm_set_config_file(const char *c_file)\fP
 .SH DESCRIPTION
 .sp
 The functions in the telemetry library facilitate the delivery of
@@ -67,8 +67,8 @@ configuration path to the telemetry library.
 .SH RETURN VALUES
 .sp
 All these functions return \fB0\fP on success, or a non\-zero return value
-if an error occurred. The functions \fBtm_free_record()\fP and \fBtm_set_config_file()\fP
-do not return any values.
+if an error occurred. The function \fBtm_free_record()\fP does not return
+any value.
 .SH SEE ALSO
 .INDENT 0.0
 .IP \(bu 2

--- a/docs/man/telemetry.3.rst
+++ b/docs/man/telemetry.3.rst
@@ -25,7 +25,7 @@ SYNOPSIS
 
 ``void tm_free_record(struct telem_ref *t_ref)``
 
-``void tm_set_config_file(char *c_file)``
+``int tm_set_config_file(const char *c_file)``
 
 
 DESCRIPTION
@@ -54,8 +54,8 @@ RETURN VALUES
 =============
 
 All these functions return ``0`` on success, or a non-zero return value
-if an error occurred. The functions ``tm_free_record()`` and ``tm_set_config_file()``
-do not return any values.
+if an error occurred. The function ``tm_free_record()`` does not return
+any value.
 
 
 SEE ALSO

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -63,7 +63,7 @@ typedef struct configuration {
 } configuration;
 
 /* Sets the configuration file to be used later */
-void set_config_file(char *filename);
+int set_config_file(const char *filename);
 
 /* Parses the ini format config file */
 bool read_config_from_file(char *filename, struct configuration *config);

--- a/src/local.mk
+++ b/src/local.mk
@@ -11,7 +11,8 @@ bin_PROGRAMS = \
 	%D%/journal/journal.h
 
 %C%_telemprobd_LDADD = $(CURL_LIBS) \
-	%D%/libtelem-shared.la
+	%D%/libtelem-shared.la \
+	%D%/libtelemetry.la
 
 %C%_telemprobd_CFLAGS = \
 	$(AM_CFLAGS)
@@ -51,7 +52,8 @@ endif
 	%D%/iorecord.h
 
 %C%_telempostd_LDADD = $(CURL_LIBS) \
-	%D%/libtelem-shared.la
+	%D%/libtelem-shared.la \
+	%D%/libtelemetry.la
 
 %C%_telempostd_CFLAGS = \
 	$(AM_CFLAGS)

--- a/src/post.c
+++ b/src/post.c
@@ -21,6 +21,7 @@
 #include <stdbool.h>
 #include <sys/stat.h>
 
+#include "telemetry.h"
 #include "log.h"
 #include "spool.h"
 #include "configuration.h"
@@ -40,9 +41,7 @@ int main(int argc, char **argv)
 {
 
         int c;
-        int ret = 0;
         int opt_index = 0;
-        char *config_file = NULL;
         TelemPostDaemon daemon;
 
         struct option opts[] = {
@@ -55,17 +54,11 @@ int main(int argc, char **argv)
         while ((c = getopt_long(argc, argv, "f:hV", opts, &opt_index)) != -1) {
                 switch (c) {
                         case 'f':
-                                config_file = optarg;
-                                struct stat buf;
-                                ret = stat(config_file, &buf);
-
-                                /* check if the file exists and is a regular file */
-                                if (ret == -1 || !S_ISREG(buf.st_mode)) {
-                                        telem_log(LOG_ERR, "Configuration file"
+                                if (tm_set_config_file(optarg) != 0) {
+                                    telem_log(LOG_ERR, "Configuration file"
                                                   " path not valid\n");
-                                        exit(EXIT_FAILURE);
+                                    exit(EXIT_FAILURE);
                                 }
-                                set_config_file(config_file);
                                 break;
                         case 'V':
                                 printf(PACKAGE_VERSION "\n");

--- a/src/probe.c
+++ b/src/probe.c
@@ -31,6 +31,7 @@
 #include <signal.h>
 #include <malloc.h>
 
+#include "telemetry.h"
 #include "config.h"
 #include "common.h"
 #ifdef  HAVE_SYSTEMD_SD_DAEMON_H
@@ -74,7 +75,6 @@ int main(int argc, char **argv)
         client *cl = NULL;
         client *current_client = NULL;
         int c;
-        char *config_file = NULL;
         int opt_index = 0;
         sigset_t mask;
         //bool interrupted = false;
@@ -92,18 +92,12 @@ int main(int argc, char **argv)
 
         while ((c = getopt_long(argc, argv, "f:hV", opts, &opt_index)) != -1) {
                 switch (c) {
-                        case 'f':
-                                config_file = optarg;
-                                struct stat buf;
-                                ret = stat(config_file, &buf);
-
-                                /* check if the file exists and is a regular file */
-                                if (ret == -1 || !S_ISREG(buf.st_mode)) {
-                                        telem_log(LOG_ERR, "Configuration file"
+                         case 'f':
+                                if (tm_set_config_file(optarg) != 0) {
+                                    telem_log(LOG_ERR, "Configuration file"
                                                   " path not valid\n");
-                                        exit(EXIT_FAILURE);
+                                    exit(EXIT_FAILURE);
                                 }
-                                set_config_file(config_file);
                                 break;
                         case 'h':
                                 print_usage(argv[0]);

--- a/src/probes/crash_probe.c
+++ b/src/probes/crash_probe.c
@@ -463,7 +463,6 @@ static bool is_banned_path(char *fullpath)
         return false;
 }
 
-static char *config_file = NULL;
 static char *core_file = NULL;
 static char *proc_path = NULL;
 static long int signal_num = -1;
@@ -490,7 +489,7 @@ static void print_help(void)
         printf("  -h, --help            Show help options\n");
         printf("\n");
         printf("Application Options:\n");
-        printf("  -f, --config-file     Path to configuration file (not implemented yet)\n");
+        printf("  -f, --config_file     Specify a configuration file other than default\n");
         printf("  -c, --core-file       Path to core file to process\n");
         printf("  -p, --process-name    Name of process for crash report (required)\n");
         printf("  -E, --process-path    Absolute path of crashed process, with ! or / delimiters\n");
@@ -532,7 +531,11 @@ int main(int argc, char **argv)
                                 printf(PACKAGE_VERSION "\n");
                                 goto success;
                         case 'f':
-                                config_file = strdup(optarg);
+                                if (tm_set_config_file(optarg) != 0) {
+                                    telem_log(LOG_ERR, "Configuration file"
+                                                  " path not valid\n");
+                                    exit(EXIT_FAILURE);
+                                }
                                 break;
                         case 'c':
                                 core_file = strdup(optarg);

--- a/src/probes/hello.c
+++ b/src/probes/hello.c
@@ -23,6 +23,7 @@
 #include "telemetry.h"
 
 #include "config.h"
+#include "log.h"
 
 static void print_usage(char *prog)
 {
@@ -56,23 +57,13 @@ int main(int argc, char **argv)
         };
 
         while ((c = getopt_long(argc, argv, "f:hHV", opts, &opt_index)) != -1) {
-                char *cfile = NULL;
                 switch (c) {
                         case 'f':
-                                if (asprintf(&cfile, "%s", (char *)optarg) < 0) {
-                                        exit(EXIT_FAILURE);
+                                if (tm_set_config_file(optarg) != 0) {
+                                    telem_log(LOG_ERR, "Configuration file"
+                                                  " path not valid\n");
+                                    exit(EXIT_FAILURE);
                                 }
-
-                                struct stat buf;
-                                ret = stat(cfile, &buf);
-
-                                /* check if the file exists and is a regular file */
-                                if (ret == -1 || !S_ISREG(buf.st_mode)) {
-                                        exit(EXIT_FAILURE);
-                                }
-
-                                tm_set_config_file(cfile);
-                                free(cfile);
                                 break;
                         case 'H':
                                 str = "org.clearlinux/heartbeat/ping";

--- a/src/probes/journal.c
+++ b/src/probes/journal.c
@@ -312,8 +312,6 @@ static bool process_journal(void)
         }
 }
 
-static char *config_file = NULL;
-
 static const struct option prog_opts[] = {
         { "help", no_argument, 0, 'h' },
         { "config-file", required_argument, 0, 'f' },
@@ -330,14 +328,9 @@ static void print_help(void)
         printf("  -h, --help            Show help options\n");
         printf("\n");
         printf("Application Options:\n");
-        printf("  -f, --config-file     Path to configuration file (not implemented yet)\n");
+        printf("  -f, --config_file     Specify a configuration file other than default\n");
         printf("  -V, --version         Print the program version\n");
         printf("\n");
-}
-
-static void free_strings(void)
-{
-        free(config_file);
 }
 
 int main(int argc, char **argv)
@@ -354,7 +347,11 @@ int main(int argc, char **argv)
                                 printf(PACKAGE_VERSION "\n");
                                 goto success;
                         case 'f':
-                                config_file = strdup(optarg);
+                                if (tm_set_config_file(optarg) != 0) {
+                                    telem_log(LOG_ERR, "Configuration file"
+                                                  " path not valid\n");
+                                    exit(EXIT_FAILURE);
+                                }
                                 break;
                 }
         }
@@ -366,8 +363,6 @@ int main(int argc, char **argv)
 success:
         ret = EXIT_SUCCESS;
 fail:
-        free_strings();
-
         if (journal) {
                 sd_journal_close(journal);
         }

--- a/src/telemetry.c
+++ b/src/telemetry.c
@@ -777,9 +777,9 @@ static int set_payload_format_header(struct telem_ref *t_ref, uint32_t payload_v
         return status;
 }
 
-void tm_set_config_file(char *c_file)
+int tm_set_config_file(const char *c_file)
 {
-        set_config_file(c_file);
+        return set_config_file(c_file);
 }
 
 /**

--- a/src/telemetry.h
+++ b/src/telemetry.h
@@ -58,11 +58,11 @@ struct telem_ref {
 /**
  * Set the configuration file name to use
  *
- * @param c_file Absolute file name of the configuration file. If the path name
- * provided is not an absolute path, or the path given cannot be successfuly
- * stat'd, then the effective configuration file is left unchanged.
+ * @param c_file Absolute file name of the configuration file.
+ * @return 0 on success, or a negative errno-style value on error. In case of 
+ *     an error return the effective configuration file is left unchanged.
  */
-void tm_set_config_file(char *c_file);
+int tm_set_config_file(const char *c_file);
 
 /**
  * Create a new telemetrics record


### PR DESCRIPTION
This change was on a TODO list for a few years.
The function tm_set_config_file could silently fail as it did not
return any status. This forced implementing of all error checks by
the callers of this function.
The current implementation does its own error checks and string copying.
The function returns an error code if errors were encountered.
Since this is a library function, all callers needed to be modified as well.
However, the modifications are code simplifications so this is not too painful.
In addition, the change also affected library documentation as well (void -> int).

As a direct consequence, this change allows simple implementation of the command
line argument "--config_file" uniformly across all probes.

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>