### PR TITLE
pythonprobe: don't use inotify

### DIFF
--- a/scripts/telemctl
+++ b/scripts/telemctl
@@ -6,7 +6,7 @@ declare -a SPECIAL_UNITS=(
   telempostd.path
   klogscanner.service
   journal-probe.service
-  python-probe.service
+  python-probe.path
 )
 
 declare -a SERVICES=(

--- a/src/data/local.mk
+++ b/src/data/local.mk
@@ -17,6 +17,7 @@ EXTRA_DIST += \
 	%D%/bert-probe.service.in \
 	%D%/journal-probe.service.in \
 	%D%/python-probe.service.in \
+	%D%/python-probe.path.in \
 	%D%/pstore-probe.service.in \
 	%D%/klogscanner.service.in \
 	%D%/pstore-clean.service.in \
@@ -54,6 +55,7 @@ systemdunit_DATA = \
 	%D%/bert-probe.service \
 	%D%/journal-probe.service \
 	%D%/python-probe.service \
+	%D%/python-probe.path \
 	%D%/pstore-probe.service \
 	%D%/klogscanner.service \
 	%D%/pstore-clean.service \
@@ -90,6 +92,9 @@ systemdunit_DATA = \
 %D%/python-probe.service: %D%/python-probe.service.in
 	$(pathfix) < $< > $@
 
+%D%/python-probe.path: %D%/python-probe.path.in
+	$(pathfix) < $< > $@
+
 %D%/telemprobd.service: %D%/telemprobd.service.in
 	$(pathfix) < $< > $@
 
@@ -114,6 +119,7 @@ clean-local:
 		%D%/telempostd.service \
 		%D%/telempostd.path \
 		%D%/python-probe.service \
+		%D%/python-probe.path \
 		%D%/telemprobd-update-trigger.service \
 		%D%/telemetrics.conf \
 		%D%/telemetrics-dirs.conf \

--- a/src/data/python-probe.path.in
+++ b/src/data/python-probe.path.in
@@ -1,0 +1,9 @@
+[Unit]
+Description=Python Probe Daemon Staging
+ConditionPathExists=!/etc/telemetrics/opt-out
+
+[Path]
+DirectoryNotEmpty=@localstatedir@/lib/telemetry/python
+
+[Install]
+WantedBy=multi-user.target

--- a/src/data/telemetrics-dirs.conf.in
+++ b/src/data/telemetrics-dirs.conf.in
@@ -1,5 +1,5 @@
 d @localstatedir@/lib/telemetry 0755 telemetry telemetry -
-d @localstatedir@/lib/telemetry/python 0777 telemetry telemetry -
+d @localstatedir@/lib/telemetry/python 01777 telemetry telemetry -
 d @localstatedir@/spool/telemetry 0750 telemetry telemetry -
 d @localstatedir@/log/telemetry 0750 telemetry telemetry -
 d @localstatedir@/log/telemetry/records 0750 telemetry telemetry -


### PR DESCRIPTION
Don't wait for new payload via inotify, let systemd path unit
detect any new payloads in /usr/lib/telemetry/python and start
the pythonprobe service.
Also set the sticky bit for the above folder, preventing users to
modify permissions.

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>