### PR TITLE
crashprobe: always remove core files, except when passing --core-file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,11 @@ src/gcc.out
 tests/demo
 tests/check_config
 tests/check_daemon
+tests/check_journal
 tests/check_libtelemetry
+tests/check_ncb64
+tests/check_postd
+tests/check_probd
 tests/check_probes
 src/data/*.path
 src/data/*.service

--- a/src/probes/crash_probe.c
+++ b/src/probes/crash_probe.c
@@ -69,7 +69,6 @@ static char error_class[30] = "org.clearlinux/crash/error";
 static char unknown_class[30] = "org.clearlinux/crash/unknown";
 
 static char temp_core[] = "/tmp/corefile-XXXXXX";
-static bool keep_core = false;
 
 static const Dwfl_Callbacks cb =
 {
@@ -609,8 +608,6 @@ int main(int argc, char **argv)
 
                 backtrace = nc_string_dup("Crash from Clear package build\n");
 
-                keep_core = true;
-
                 if (!send_data(&backtrace, unknown_severity, clr_build_class)) {
                         goto fail;
                 }
@@ -621,8 +618,6 @@ int main(int argc, char **argv)
                 telem_log(LOG_NOTICE, "Ignoring core (third-party binary)\n");
 
                 backtrace = nc_string_dup("Crash from third party\n");
-
-                keep_core = true;
 
                 if (!send_data(&backtrace, unknown_severity, unknown_class)) {
                         goto fail;
@@ -676,11 +671,6 @@ success:
 
         ret = EXIT_SUCCESS;
 fail:
-        // Do not remove the core file if any errors occur
-        if (ret == EXIT_FAILURE) {
-                keep_core = true;
-        }
-
         free(core_file);
         free(proc_name);
         free(proc_path);
@@ -710,8 +700,8 @@ fail:
         }
 
         // Remove the core file by default, except when the --core-file option
-        // is specified, or when keep_core is overridden to true.
-        if (!core_file && !keep_core) {
+        // is specified.
+        if (!core_file) {
                 unlink(temp_core);
         }
 


### PR DESCRIPTION
In modern times, the default core_pattern for Clear Linux OS is set to

```
|/usr/lib/systemd/coredump-wrapper %E %P %u %g %s %t %c %h %e
```

This wrapper script sends core files to both systemd-coredump and crashprobe (if installed).

Because systemd-coredump will store core files in the systemd journal, there is no longer a strong reason to preserve the crashprobe core files in /tmp, aside from when crashprobe's --core-file option is used. If developers wish to access core files, they can use `coredumpctl` instead to extract them from the systemd journal.