### PR TITLE
journalprobe: don't process entire journal on restart

### DIFF
--- a/scripts/telemctl
+++ b/scripts/telemctl
@@ -5,7 +5,7 @@ declare -a SPECIAL_UNITS=(
   telemprobd.socket
   telempostd.path
   klogscanner.service
-  journal-probe.service
+  journal-probe-tail.service
   python-probe.path
 )
 
@@ -14,6 +14,7 @@ declare -a SERVICES=(
   pstore-probe.service
   telemprobd.service
   telempostd.service
+  journal-probe.service
 )
 
 SCRIPT="$0"

--- a/src/data/journal-probe-tail.service.in
+++ b/src/data/journal-probe-tail.service.in
@@ -1,0 +1,12 @@
+[Unit]
+Description=Telemetrics Systemd Journal Probe
+Requires=telemprobd.socket
+After=telemprobd.socket
+ConditionPathExists=!/etc/telemetrics/opt-out
+
+[Service]
+ExecStart=@bindir@/journalprobe -t
+User=telemetry
+
+[Install]
+WantedBy=multi-user.target

--- a/src/data/local.mk
+++ b/src/data/local.mk
@@ -16,6 +16,7 @@ EXTRA_DIST += \
 	%D%/hprobe.timer \
 	%D%/bert-probe.service.in \
 	%D%/journal-probe.service.in \
+	%D%/journal-probe-tail.service.in \
 	%D%/python-probe.service.in \
 	%D%/python-probe.path.in \
 	%D%/pstore-probe.service.in \
@@ -54,6 +55,7 @@ systemdunit_DATA = \
 	%D%/hprobe.timer \
 	%D%/bert-probe.service \
 	%D%/journal-probe.service \
+	%D%/journal-probe-tail.service \
 	%D%/python-probe.service \
 	%D%/python-probe.path \
 	%D%/pstore-probe.service \
@@ -72,6 +74,9 @@ systemdunit_DATA = \
 	$(pathfix) < $< > $@
 
 %D%/journal-probe.service: %D%/journal-probe.service.in
+	$(pathfix) < $< > $@
+
+%D%/journal-probe-tail.service: %D%/journal-probe-tail.service.in
 	$(pathfix) < $< > $@
 
 %D%/pstore-probe.service: %D%/pstore-probe.service.in
@@ -126,6 +131,7 @@ clean-local:
 		%D%/libtelemetry.pc \
 		%D%/40-crash-probe.conf \
 		%D%/journal-probe.service \
+		%D%/journal-probe-tail.service \
 		%D%/pstore-probe.service \
 		%D%/klogscanner.service \
 		%D%/pstore-clean.service \


### PR DESCRIPTION
This adds an optional argument to journalprobe that allows seeking to
the end of the journal. This is then used in a new service file that is
called by telemctl on restart. This allows us to scan the entire journal
on boot, and only scan new journal entries when restarting, or opting
into telemetry manually. This reduces spam from repeated messages and
fixes a possible privacy concern, as previously running telemctl start
could include journal errors that occurred before telemetrics was opted
into.

Signed-off-by: California Sullivan <california.l.sullivan@intel.com>