### PR TITLE
pythonprobe: fix folders

### DIFF
--- a/src/data/python-probe.path.in
+++ b/src/data/python-probe.path.in
@@ -3,7 +3,7 @@ Description=Python Probe Daemon Staging
 ConditionPathExists=!/etc/telemetrics/opt-out
 
 [Path]
-DirectoryNotEmpty=@localstatedir@/lib/telemetry/python
+DirectoryNotEmpty=/var/lib/telemetry/python
 
 [Install]
 WantedBy=multi-user.target

--- a/src/data/telemetrics-dirs.conf.in
+++ b/src/data/telemetrics-dirs.conf.in
@@ -1,7 +1,8 @@
 d @localstatedir@/lib/telemetry 0755 telemetry telemetry -
-d @localstatedir@/lib/telemetry/python 01777 telemetry telemetry -
 d @localstatedir@/spool/telemetry 0750 telemetry telemetry -
 d @localstatedir@/log/telemetry 0750 telemetry telemetry -
 d @localstatedir@/log/telemetry/records 0750 telemetry telemetry -
 d @localstatedir@/cache/telemetry 0750 telemetry telemetry -
 d @localstatedir@/cache/telemetry/pstore 0750 telemetry telemetry -
+d /var/lib/telemetry/python 01777 telemetry telemetry -
+d /var/tmp/telemetry 01777 telemetry telemetry -


### PR DESCRIPTION
Python3 expects two "well known" folders to exist in order to generate exception
payloads:

/var/tmp/telemetry
/var/lib/telemetry/python

Both folders must exist at the above absolute locations in order to properly
create and submit Python3 telemetry unhandled exception payload.

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>