### PR TITLE
Improve support of non-default configuration files.

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -102,6 +102,11 @@ static const uint32_t RECORD_FORMAT_VERSION = 4;
 /* Maximum records that can be processed in a single spool run loop*/
 #define TM_SPOOL_MAX_PROCESS_RECORDS 60
 
+/* Definitions for config file override */
+#define CFG_PREFIX        "CFG:"
+#define CFG_PREFIX_LENGTH 4
+#define CFG_PREFIX_32BIT  0x3a474643
+
 /* Very simple structure. Array of header strings and a payload. Calling
  * program is reponsible for passing in the payload as a simple string.
  */
@@ -113,5 +118,6 @@ struct telem_record {
 };
 
 const char *get_header_name(int ind);
+
 
 /* vi: set ts=8 sw=8 sts=4 et tw=80 cino=(0: */

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -73,6 +73,19 @@ static int validate_config_file(const char *f)
 
 }
 
+const char *get_config_file(void)
+{
+        return config_file;
+}
+
+const char *get_cmd_line_config_file(void)
+{
+        if (cmd_line_cfg == true) {
+                return config_file;
+        }
+        return NULL;
+}
+
 int set_config_file(const char *filename)
 {
         int ret;
@@ -160,11 +173,10 @@ bool read_config_from_file(char *config_file, struct configuration *config)
                 }
         }
 
-        config->initialized = true;
         return true;
 }
 
-void initialize_config(void)
+static void initialize_config(void)
 {
         if (config.initialized) {
                 return;
@@ -195,6 +207,8 @@ void initialize_config(void)
 #endif
                 exit(EXIT_FAILURE);
         }
+
+        config.initialized = true;
 }
 
 void reload_config(void)

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -65,6 +65,12 @@ typedef struct configuration {
 /* Sets the configuration file to be used later */
 int set_config_file(const char *filename);
 
+/* Gets the configuration currently in use */
+const char *get_config_file(void);
+
+/* Gets the configuration specified via command line or NULL */
+const char *get_cmd_line_config_file(void);
+
 /* Parses the ini format config file */
 bool read_config_from_file(char *filename, struct configuration *config);
 

--- a/src/iorecord.h
+++ b/src/iorecord.h
@@ -24,7 +24,7 @@
  * @param body record message content
  *
  */
-void stage_record(char *path, char *headers[], char *body);
+void stage_record(char *path, char *headers[], char *body, char *cfg);
 
 /**
  * Reads a telemetry record
@@ -35,4 +35,4 @@ void stage_record(char *path, char *headers[], char *body);
  *
  * @return true if successful otherwise false
  */
-bool read_record(char *fullpath, char *headers[], char **body);
+bool read_record(char *fullpath, char *headers[], char **body, char **cfg);

--- a/src/post.c
+++ b/src/post.c
@@ -27,7 +27,7 @@
 #include "configuration.h"
 #include "telempostdaemon.h"
 
-bool (*post_record_ptr)(char *[], char *) = post_record_http;
+bool (*post_record_ptr)(char *[], char *, char *) = post_record_http;
 
 void print_usage(char *prog)
 {

--- a/src/telempostdaemon.h
+++ b/src/telempostdaemon.h
@@ -105,8 +105,10 @@ int staging_records_loop(TelemPostDaemon *daemon);
  *
  * @param headers a pointer to an array with keys and values
  * @param body a pointer to the payload
+ * @param cfg_file a pointer to a non-default configuration
+ *        file to be used.
  */
-bool post_record_http(char *headers[], char *body);
+bool post_record_http(char *headers[], char *body, char *cfg_file);
 
 /**
  * Pointer to function to isolate backend call during
@@ -115,7 +117,7 @@ bool post_record_http(char *headers[], char *body);
  * @param headers pointer to array of keys
  * @param body a pinter to payload
  * */
-extern bool (*post_record_ptr)(char *headers[], char *body);
+extern bool (*post_record_ptr)(char *headers[], char *body, char *cfg_file);
 
 /** Helper functions **/
 /* rate limit check */

--- a/tests/check_postd.c
+++ b/tests/check_postd.c
@@ -27,12 +27,12 @@
 
 TelemPostDaemon tdaemon;
 
-bool dummy_post(char *headers[], char *body)
+bool dummy_post(char *headers[], char *body, char *cfg_file)
 {
         return true;
 }
 
-bool (*post_record_ptr)(char *headers[], char *body) = dummy_post;
+bool (*post_record_ptr)(char *headers[], char *body, char *cfg_file) = dummy_post;
 
 void setup(void)
 {


### PR DESCRIPTION
Most probes allow passing of non-default configuration file
via command line using the "-f" switch.
For example:

$ hprobe -f custom_cfg_file.conf

If the file "custom_cfg_file.conf" contains

server = http://<my backend server>

one would expect the hprobe payload will be sent to the server
http://<my backend server>. However, this is not the case, as the
various daemons delivering the payload to the backend are blissfully
unaware of the of the config file hprobe wanted to use.

The solution is to include the absolute path of the config file
specified on the command line as part of the payload. Once the
payload is about to be sent via the routine "post_record_http",
the routine checks if a non-default config file was requested.
If so, configuration is re-initialized with the file.
Upon exit, the routine re-initializes the original (default) configuration.

The non-default file may not exist at the send time anymore,
for example when sending some spooled records. In that case we
intentionally don't send anything to the backend.

If the record does not contain the optional configuration file
information, it's business as usual.

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>