### PR TITLE
configuration: rework to allow layered configuration

### DIFF
--- a/build-aux/make/cflags.make
+++ b/build-aux/make/cflags.make
@@ -25,6 +25,7 @@ AM_CPPFLAGS = \
 	-DDATADIR=\"$(datadir)\" \
 	-DLOCALSTATEDIR=\"$(localstatedir)\" \
 	-DPSTOREDIR=\"$(localstatedir)/cache/telemetry/pstore\" \
-	-DTESTOOPSDIR=\"$(top_srcdir)/tests/oops_test_files\"
+	-DTESTOOPSDIR=\"$(top_srcdir)/tests/oops_test_files\" \
+	-DBACKEND_ADDR=\"$(BACKEND_ADDR)\"
 
 # vim: filetype=automake tabstop=8 shiftwidth=8 noexpandtab

--- a/configure.ac
+++ b/configure.ac
@@ -119,6 +119,11 @@ AC_ARG_WITH([loglevel], AS_HELP_STRING([--with-loglevel=NUM],
 	    [loglevel=5])
 AC_DEFINE_UNQUOTED([MAX_LOG_LEVEL], [${loglevel}], [Maximum log level for binaries])
 
+AC_ARG_WITH([backendserveraddr], AS_HELP_STRING([--with-backendserveraddr=URI],
+	    [uri to telemetrics backend server @<:@default=https://clr.telemetry.intel.com/v2/collector@:>@]), [backendaddr=${withval}])
+test -z "${backendaddr}" && backendaddr=https://clr.telemetry.intel.com/v2/collector
+AC_SUBST(BACKEND_ADDR, [${backendaddr}])
+
 AC_ARG_ENABLE([logtype], AS_HELP_STRING([--enable-logtype],
               [Vector for logging: stderr (default), syslog, systemd]),
 			  [case ${enableval} in

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -18,13 +18,31 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+/* Default configuration settings */
+#define DEFAULT_SERVER_ADDR BACKEND_ADDR
+#define DEFAULT_SOCKET_PATH "/run/telem-0"
+#define DEFAULT_SPOOL_DIR LOCALSTATEDIR "/spool/telemetry"
+#define DEFAULT_RATE_LIMIT_STRATEGY "spool"
+#define DEFAULT_CAINFO ""
+#define DEFAULT_TIDHEADER "X-Telemetry-TID: 6907c830-eed9-4ce9-81ae-76daf8d88f0f"
+
+#define DEFAULT_RECORD_EXPIRY 1200
+#define DEFAULT_SPOOL_MAX_SIZE 5120
+#define DEFAULT_SPOOL_PROCESS_TIME 120
+#define DEFAULT_RECORD_WINDOW_LENGTH 15
+#define DEFAULT_BYTE_WINDOW_LENGTH 20
+#define DEFAULT_RECORD_BURST_LIMIT 1000
+#define DEFAULT_BYTE_BURST_LIMIT -1
+
+#define DEFAULT_RATE_LIMIT_ENABLED true
+#define DEFAULT_DAEMON_RECYCLING_ENABLED true
+#define DEFAULT_RECORD_RETENTION_ENABLED false
+#define DEFAULT_RECORD_SERVER_DELIVERY_ENABLED true
+
 #define TM_MAX_WINDOW_LENGTH (1 /*h*/ * 60 /*m*/)
-#define RECORD_RETENTION_ENABLED_DEFAULT false
-#define RECORD_SERVER_DELIVERY_ENABLED_DEFAULT true
 
 enum config_str_keys {
-        CONF_STR_MIN = 0,
-        CONF_SERVER_ADDR,
+        CONF_SERVER_ADDR = 0,
         CONF_SOCKET_PATH,
         CONF_SPOOL_DIR,
         CONF_RATE_LIMIT_STRATEGY,
@@ -34,8 +52,7 @@ enum config_str_keys {
 };
 
 enum config_int_keys {
-        CONF_INT_MIN = 0,
-        CONF_RECORD_EXPIRY,
+        CONF_RECORD_EXPIRY = 0,
         CONF_SPOOL_MAX_SIZE,
         CONF_SPOOL_PROCESS_TIME,
         CONF_RECORD_WINDOW_LENGTH,
@@ -46,8 +63,7 @@ enum config_int_keys {
 };
 
 enum config_bool_keys {
-        CONF_BOOL_MIN = 0,
-        CONF_RATE_LIMIT_ENABLED,
+        CONF_RATE_LIMIT_ENABLED = 0,
         CONF_DAEMON_RECYCLING_ENABLED,
         CONF_RECORD_RETENTION_ENABLED,
         CONF_RECORD_SERVER_DELIVERY_ENABLED,
@@ -70,6 +86,9 @@ const char *get_config_file(void);
 
 /* Gets the configuration specified via command line or NULL */
 const char *get_cmd_line_config_file(void);
+
+/* Sets all default configuration values to a given config */
+bool set_default_config_values(struct configuration *config);
 
 /* Parses the ini format config file */
 bool read_config_from_file(char *filename, struct configuration *config);

--- a/src/data/example.2.conf
+++ b/src/data/example.2.conf
@@ -1,0 +1,4 @@
+[settings]
+server=http://127.0.0.1
+
+cainfo=/tmp/cacert.crt

--- a/src/data/local.mk
+++ b/src/data/local.mk
@@ -5,13 +5,15 @@ pathfix = @sed \
 	-e 's|@localstatedir[@]|$(localstatedir)|g' \
 	-e 's|@PACKAGE_VERSION[@]|$(PACKAGE_VERSION)|g' \
 	-e 's|@SOCKETDIR[@]|$(SOCKETDIR)|g' \
-	-e 's|@systemctldir[@]|$(SYSTEMD_SYSTEMCTLDIR)|g'
+	-e 's|@systemctldir[@]|$(SYSTEMD_SYSTEMCTLDIR)|g' \
+	-e 's|@BACKEND_ADDR[@]|$(BACKEND_ADDR)|g'
 
 EXTRA_DIST += \
 	%D%/40-core-ulimit.conf \
 	%D%/40-crash-probe.conf.in \
 	%D%/example.conf \
 	%D%/example.1.conf \
+	%D%/example.2.conf \
 	%D%/hprobe.service.in \
 	%D%/hprobe.timer \
 	%D%/bert-probe.service.in \

--- a/src/data/telemetrics.conf.in
+++ b/src/data/telemetrics.conf.in
@@ -1,67 +1,69 @@
+# values represent their default state
+# copy to /etc/telemetrics/telemetrics.conf and modify for user config
 [settings]
 # ip address of destination server for record delivery
-server=https://clr.telemetry.intel.com/v2/collector
+#server=@BACKEND_ADDR@
 
-socket_path=@SOCKETDIR@/telem-0
+#socket_path=@SOCKETDIR@/telem-0
 
 # certificate file to use to validate ssl endpoint
-cainfo=
+#cainfo=
 
 # Telemetry id - post header used to group records in ingestion service,
 # which may be ingesting for more than one set of clients. Can be set
 # to any string.
-tidheader=X-Telemetry-TID:\s6907c830-eed9-4ce9-81ae-76daf8d88f0f
+#tidheader=X-Telemetry-TID:\s6907c830-eed9-4ce9-81ae-76daf8d88f0f
 
 # record expiry time in minutes
-record_expiry=1200
+#record_expiry=1200
 
-spool_dir=@localstatedir@/spool/telemetry
+#spool_dir=@localstatedir@/spool/telemetry
 
 # maximum size of the spool directory in KB, -1 = quota disabled.
 # The block size of the files in this directory is considered,
 # and not the actual size of the record itself.
-spool_max_size=5120
+#spool_max_size=5120
 
 # time in seconds for processing spool
 # Valid range: 120..300. Values outside this range are clamped.
-spool_process_time=120
+#spool_process_time=120
 
 # rate limit enabled - if this is set to false then all rate-limiting disabled.
 # It is possible to disable each rate-limit individually below.
-rate_limit_enabled=true
+#rate_limit_enabled=true
 
 # rate limiting record burst limit
 # Valid Range:  0..INT_MAX, -1 = disabled.
-record_burst_limit=1000
+#record_burst_limit=1000
 
 # rate limiting record window length in minutes
 # Valid Range: 0..59
-record_window_length=15
+#record_window_length=15
 
 # rate limiting byte burst limit
 # Valid Range:  0..INT_MAX, -1 = disabled.
-byte_burst_limit=-1
+#byte_burst_limit=-1
 
 # rate limiting byte window length in minutes
 # Valid Range: 0..59
-byte_window_length=20
+#byte_window_length=20
 
 # rate limit strategy - what to do with record if rate-limiting prevents 
 # delivery over network
 # Valid stategies: spool, drop
-rate_limit_strategy=spool
+#rate_limit_strategy=spool
 
 # daemon recycling enabled - if daemon has been running for a while (2 hours),
 # has not any client nor spool data, then it exits.
 # this is to ensure that latest code runs.
-daemon_recycling_enabled=true
+#daemon_recycling_enabled=true
 
 # record server delivery enabled - when enabled records will be delivered
 # to server otherwise records will be ignored. This configuration can be used
 # with 'record_retention_enable' configuration value to keep records local only.
-record_server_delivery_enabled=true
+#record_server_delivery_enabled=true
 
 # record retention enabled - when enabled a copy of reported telemetry records
 # will be kept locally. This configuration combined with 'record_server_delivery_enabled'
 # value can be used to keep records local only.
-record_retention_enabled=false
+#record_retention_enabled=false

--- a/tests/check_config.c
+++ b/tests/check_config.c
@@ -55,18 +55,61 @@ START_TEST(check_read_valid_config)
 }
 END_TEST
 
-START_TEST(check_read_valid_config_defaults)
+START_TEST(check_default_config)
 {
-        char *config_file = TOPSRCDIR "/src/data/example.conf";
+        configuration config = { { 0 }, { 0 }, { 0 }, false, NULL };
+        int ret = set_default_config_values(&config);
+        ck_assert(ret == true);
+
+        ck_assert_str_eq(config.strValues[CONF_SERVER_ADDR], DEFAULT_SERVER_ADDR);
+        ck_assert_str_eq(config.strValues[CONF_SOCKET_PATH], DEFAULT_SOCKET_PATH);
+        ck_assert_str_eq(config.strValues[CONF_SPOOL_DIR], DEFAULT_SPOOL_DIR);
+        ck_assert_str_eq(config.strValues[CONF_RATE_LIMIT_STRATEGY], DEFAULT_RATE_LIMIT_STRATEGY);
+        ck_assert_str_eq(config.strValues[CONF_CAINFO], DEFAULT_CAINFO);
+        ck_assert_str_eq(config.strValues[CONF_TIDHEADER], DEFAULT_TIDHEADER);
+
+        ck_assert_int_eq(config.intValues[CONF_RECORD_EXPIRY], DEFAULT_RECORD_EXPIRY);
+        ck_assert_int_eq(config.intValues[CONF_SPOOL_MAX_SIZE], DEFAULT_SPOOL_MAX_SIZE);
+        ck_assert_int_eq(config.intValues[CONF_SPOOL_PROCESS_TIME], DEFAULT_SPOOL_PROCESS_TIME);
+        ck_assert_int_eq(config.intValues[CONF_RECORD_WINDOW_LENGTH], DEFAULT_RECORD_WINDOW_LENGTH);
+        ck_assert_int_eq(config.intValues[CONF_BYTE_WINDOW_LENGTH], DEFAULT_BYTE_WINDOW_LENGTH);
+        ck_assert_int_eq(config.intValues[CONF_RECORD_BURST_LIMIT], DEFAULT_RECORD_BURST_LIMIT);
+        ck_assert_int_eq(config.intValues[CONF_BYTE_BURST_LIMIT], DEFAULT_BYTE_BURST_LIMIT);
+
+        ck_assert(config.boolValues[CONF_RATE_LIMIT_ENABLED] == DEFAULT_RATE_LIMIT_ENABLED);
+        ck_assert(config.boolValues[CONF_DAEMON_RECYCLING_ENABLED] == DEFAULT_DAEMON_RECYCLING_ENABLED);
+        ck_assert(config.boolValues[CONF_RECORD_RETENTION_ENABLED] == DEFAULT_RECORD_RETENTION_ENABLED);
+        ck_assert(config.boolValues[CONF_RECORD_SERVER_DELIVERY_ENABLED] == DEFAULT_RECORD_SERVER_DELIVERY_ENABLED);
+}
+END_TEST
+
+START_TEST(check_layered_config)
+{
+        char *config_file = TOPSRCDIR "/src/data/example.2.conf";
         configuration config = { { 0 }, { 0 }, { 0 }, false, NULL };
 
         int ret = read_config_from_file(config_file, &config);
         ck_assert(ret == true);
 
-        // RECORD_RETENTION_ENABLED_DEFAULT = false
-        ck_assert(config.boolValues[CONF_RECORD_RETENTION_ENABLED] == RECORD_RETENTION_ENABLED_DEFAULT);
-        // RECORD_SERVER_DELIVERY_ENABLED_DEFAULT = true
-        ck_assert(config.boolValues[CONF_RECORD_SERVER_DELIVERY_ENABLED] == RECORD_SERVER_DELIVERY_ENABLED_DEFAULT);
+        ck_assert_str_eq(config.strValues[CONF_SERVER_ADDR], "http://127.0.0.1");
+        ck_assert_str_eq(config.strValues[CONF_SOCKET_PATH], DEFAULT_SOCKET_PATH);
+        ck_assert_str_eq(config.strValues[CONF_SPOOL_DIR], DEFAULT_SPOOL_DIR);
+        ck_assert_str_eq(config.strValues[CONF_RATE_LIMIT_STRATEGY], DEFAULT_RATE_LIMIT_STRATEGY);
+        ck_assert_str_eq(config.strValues[CONF_CAINFO], "/tmp/cacert.crt");
+        ck_assert_str_eq(config.strValues[CONF_TIDHEADER], DEFAULT_TIDHEADER);
+
+        ck_assert_int_eq(config.intValues[CONF_RECORD_EXPIRY], DEFAULT_RECORD_EXPIRY);
+        ck_assert_int_eq(config.intValues[CONF_SPOOL_MAX_SIZE], DEFAULT_SPOOL_MAX_SIZE);
+        ck_assert_int_eq(config.intValues[CONF_SPOOL_PROCESS_TIME], DEFAULT_SPOOL_PROCESS_TIME);
+        ck_assert_int_eq(config.intValues[CONF_RECORD_WINDOW_LENGTH], DEFAULT_RECORD_WINDOW_LENGTH);
+        ck_assert_int_eq(config.intValues[CONF_BYTE_WINDOW_LENGTH], DEFAULT_BYTE_WINDOW_LENGTH);
+        ck_assert_int_eq(config.intValues[CONF_RECORD_BURST_LIMIT], DEFAULT_RECORD_BURST_LIMIT);
+        ck_assert_int_eq(config.intValues[CONF_BYTE_BURST_LIMIT], DEFAULT_BYTE_BURST_LIMIT);
+
+        ck_assert(config.boolValues[CONF_RATE_LIMIT_ENABLED] == DEFAULT_RATE_LIMIT_ENABLED);
+        ck_assert(config.boolValues[CONF_DAEMON_RECYCLING_ENABLED] == DEFAULT_DAEMON_RECYCLING_ENABLED);
+        ck_assert(config.boolValues[CONF_RECORD_RETENTION_ENABLED] == DEFAULT_RECORD_RETENTION_ENABLED);
+        ck_assert(config.boolValues[CONF_RECORD_SERVER_DELIVERY_ENABLED] == DEFAULT_RECORD_SERVER_DELIVERY_ENABLED);
 }
 END_TEST
 
@@ -117,7 +160,8 @@ Suite *config_suite(void)
         TCase *t = tcase_create("config");
         tcase_add_test(t, check_read_config_for_invalid_file);
         tcase_add_test(t, check_read_valid_config);
-        tcase_add_test(t, check_read_valid_config_defaults);
+        tcase_add_test(t, check_default_config);
+        tcase_add_test(t, check_layered_config);
         tcase_add_test(t, check_read_valid_config_record_retention_delivery);
         tcase_add_test(t, check_config_initialised);
 


### PR DESCRIPTION
Have a default configuration set in the binary, with conf files only
being used to change from the defaults. This allows making simpler
configs which only toggle specific options, which may be useful for user
configuration or testing. See src/data/example.2.conf for an example of
a new simplified config.

The default backend server can be changed via the configure flag
--with-backendserveraddr=URI. This allows anyone else using this project
to easily specify their own default backend without patching.

Signed-off-by: California Sullivan <california.l.sullivan@intel.com>