### PR TITLE
telempostdaemon: fix retries loop

### DIFF
--- a/src/telempostdaemon.c
+++ b/src/telempostdaemon.c
@@ -616,7 +616,7 @@ int staging_records_loop(TelemPostDaemon *daemon)
 void run_daemon(TelemPostDaemon *daemon)
 {
         int ret;
-        int retry_attempt = MAX_RETRY_ATTEMPTS;
+        int retry_attempt = 0;
         int spool_process_time = spool_process_time_config();
         bool daemon_recycling_enabled = daemon_recycling_enabled_config();
         time_t last_spool_run_time = time(NULL);
@@ -713,7 +713,7 @@ void run_daemon(TelemPostDaemon *daemon)
                                 break;
                         }
                         /* Check if this is a retry */
-                        if (retry_attempt < MAX_RETRY_ATTEMPTS) {
+                        if ((retry_attempt > 0) && (retry_attempt < MAX_RETRY_ATTEMPTS)) {
                                 if (staging_records_loop(daemon) == 0) {
                                         retry_attempt = MAX_RETRY_ATTEMPTS + 1;
                                 } else {


### PR DESCRIPTION
The 'else if (retry_attempt == MAX_RETRY_ATTEMPTS)' section would get
hit the first time through the loop on every invokation, printing the
failed to deliver error to the journal.

To fix it, initialize retry_attempt to zero and check that we're above
zero retries to enter the retry section.

Signed-off-by: California Sullivan <california.l.sullivan@intel.com>