### PR TITLE
daemons: name space separation

### DIFF
--- a/src/iorecord.c
+++ b/src/iorecord.c
@@ -41,63 +41,6 @@ bool _fgets(char *s, int n, FILE *stream)
         return true;
 }
 
-void stage_record(char *filepath, char *headers[], char *body, char *cfg_file)
-{
-        int tmpfd;
-        FILE *tmpfile = NULL;
-
-#ifdef DEBUG
-        fprintf(stderr, "DEBUG: [%s] filepath:%s\n",__func__, filepath);
-        fprintf(stderr, "DEBUG: [%s] body:%s\n",__func__, body);
-        fprintf(stderr, "DEBUG: [%s] cfg:%s\n",__func__, cfg_file);
-#endif
-        // Use default path if not provided
-        if (filepath == NULL) {
-                telem_log(LOG_ERR, "filepath value must be provided, aborting\n");
-                exit(EXIT_FAILURE);
-        }
-
-        tmpfd = mkstemp(filepath);
-        if (!tmpfd) {
-                telem_perror("Error opening staging file");
-                close(tmpfd);
-                if (unlink(filepath)) {
-                        telem_perror("Error deleting staging file");
-                }
-                goto clean_exit;
-        }
-
-        // open file
-        tmpfile = fdopen(tmpfd, "a");
-        if (!tmpfile) {
-                telem_perror("Error opening temp stage file");
-                close(tmpfd);
-                if (unlink(filepath)) {
-                        telem_perror("Error deleting temp stage file");
-                }
-                goto clean_exit;
-        }
-
-        // write cfg info if exists
-        if (cfg_file != NULL) {
-                fprintf(tmpfile, "%s%s\n", CFG_PREFIX, cfg_file);
-        }
-
-        // write headers
-        for (int i = 0; i < NUM_HEADERS; i++) {
-                fprintf(tmpfile, "%s\n", headers[i]);
-        }
-
-        //write body
-        fprintf(tmpfile, "%s\n", body);
-        fflush(tmpfile);
-        fclose(tmpfile);
-
-clean_exit:
-
-        return;
-}
-
 bool read_record(char *fullpath, char *headers[], char **body, char **cfg_file)
 {
         int i, ret = 0;

--- a/src/iorecord.h
+++ b/src/iorecord.h
@@ -17,16 +17,6 @@
 #include <stdbool.h>
 
 /**
- * Save a telemetry record to disk
- *
- * @param path pointer to a directory to save record
- * @param headers pointer to array of headers and values
- * @param body record message content
- *
- */
-void stage_record(char *path, char *headers[], char *body, char *cfg);
-
-/**
  * Reads a telemetry record
  *
  * @param fullpath pointer to full path file name

--- a/src/local.mk
+++ b/src/local.mk
@@ -6,7 +6,6 @@ bin_PROGRAMS = \
 	%D%/probe.c \
 	%D%/telemdaemon.c \
 	%D%/telemdaemon.h \
-	%D%/iorecord.c \
 	%D%/journal/journal.c \
 	%D%/journal/journal.h
 

--- a/src/post.c
+++ b/src/post.c
@@ -72,7 +72,7 @@ int main(int argc, char **argv)
                 }
         }
 
-        initialize_daemon(&daemon);
+        initialize_post_daemon(&daemon);
 
         daemon.current_spool_size = get_spool_dir_size();
 

--- a/src/probe.c
+++ b/src/probe.c
@@ -111,7 +111,7 @@ int main(int argc, char **argv)
                                 exit(EXIT_FAILURE);
                 }
         }
-        initialize_daemon(&daemon);
+        initialize_probe_daemon(&daemon);
 
         sigemptyset(&mask);
 

--- a/src/telemdaemon.c
+++ b/src/telemdaemon.c
@@ -36,7 +36,7 @@
 #include "log.h"
 #include "configuration.h"
 
-void initialize_daemon(TelemDaemon *daemon)
+void initialize_probe_daemon(TelemDaemon *daemon)
 {
         client_list_head head;
         LIST_INIT(&head);
@@ -245,6 +245,63 @@ void machine_id_replace(char **machine_header, char *machine_id_override)
                 exit(EXIT_FAILURE);
         }
         free(old_header);
+}
+
+static void stage_record(char *filepath, char *headers[], char *body, char *cfg_file)
+{
+        int tmpfd;
+        FILE *tmpfile = NULL;
+
+#ifdef DEBUG
+        fprintf(stderr, "DEBUG: [%s] filepath:%s\n",__func__, filepath);
+        fprintf(stderr, "DEBUG: [%s] body:%s\n",__func__, body);
+        fprintf(stderr, "DEBUG: [%s] cfg:%s\n",__func__, cfg_file);
+#endif
+        // Use default path if not provided
+        if (filepath == NULL) {
+                telem_log(LOG_ERR, "filepath value must be provided, aborting\n");
+                exit(EXIT_FAILURE);
+        }
+
+        tmpfd = mkstemp(filepath);
+        if (!tmpfd) {
+                telem_perror("Error opening staging file");
+                close(tmpfd);
+                if (unlink(filepath)) {
+                        telem_perror("Error deleting staging file");
+                }
+                goto clean_exit;
+        }
+
+        // open file
+        tmpfile = fdopen(tmpfd, "a");
+        if (!tmpfile) {
+                telem_perror("Error opening temp stage file");
+                close(tmpfd);
+                if (unlink(filepath)) {
+                        telem_perror("Error deleting temp stage file");
+                }
+                goto clean_exit;
+        }
+
+        // write cfg info if exists
+        if (cfg_file != NULL) {
+                fprintf(tmpfile, "%s%s\n", CFG_PREFIX, cfg_file);
+        }
+
+        // write headers
+        for (int i = 0; i < NUM_HEADERS; i++) {
+                fprintf(tmpfile, "%s\n", headers[i]);
+        }
+
+        //write body
+        fprintf(tmpfile, "%s\n", body);
+        fflush(tmpfile);
+        fclose(tmpfile);
+
+clean_exit:
+
+        return;
 }
 
 void process_record(TelemDaemon *daemon, client *cl)

--- a/src/telemdaemon.h
+++ b/src/telemdaemon.h
@@ -62,7 +62,7 @@ typedef struct TelemDaemon {
  *
  * @param daemon A pointer to the daemon structure.
  */
-void initialize_daemon(TelemDaemon *daemon);
+void initialize_probe_daemon(TelemDaemon *daemon);
 
 /**
  * Add poll fd struct to the array of pollfds.

--- a/src/telempostdaemon.c
+++ b/src/telempostdaemon.c
@@ -178,7 +178,7 @@ static void initialize_record_delivery(TelemPostDaemon *daemon)
         daemon->record_server_delivery_enabled = record_server_delivery_enabled_config();
 }
 
-void initialize_daemon(TelemPostDaemon *daemon)
+void initialize_post_daemon(TelemPostDaemon *daemon)
 {
         assert(daemon);
 

--- a/src/telempostdaemon.h
+++ b/src/telempostdaemon.h
@@ -65,7 +65,7 @@ typedef struct TelemPostDaemon {
  *
  * @param daemon a pointer to telemetry post daemon
  */
-void initialize_daemon(TelemPostDaemon *daemon);
+void initialize_post_daemon(TelemPostDaemon *daemon);
 
 /**
  * Starts daemon

--- a/tests/check_postd.c
+++ b/tests/check_postd.c
@@ -39,7 +39,7 @@ void setup(void)
         char *config_file = ABSTOPSRCDIR "/src/data/example.conf";
         set_config_file(config_file);
 
-        initialize_daemon(&tdaemon);
+        initialize_post_daemon(&tdaemon);
 }
 
 START_TEST(check_daemon_is_initialized)

--- a/tests/check_probd.c
+++ b/tests/check_probd.c
@@ -58,7 +58,7 @@ void setup(void)
         char *config_file = ABSTOPSRCDIR "/src/data/example.conf";
         set_config_file(config_file);
 
-        initialize_daemon(&tdaemon);
+        initialize_probe_daemon(&tdaemon);
 }
 
 START_TEST(check_daemon_is_initialized)


### PR DESCRIPTION
The telempostd and telemprobd daemons both used identical
name "initialize_daemon" for daemon initialization.
Although the name was identical, the code for each daemon initialization
was different, leading to some potential confusion.
Also moved telemprobd specific code "stage_record" from iorecord.c to
telemdaemon.c
Modified local.mk accordingly.

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>