### PR TITLE
Update logging

### DIFF
--- a/src/iorecord.c
+++ b/src/iorecord.c
@@ -88,14 +88,9 @@ bool read_record(char *fullpath, char *headers[], char **body, char **cfg_file)
                         goto read_error;
                 }
                 strcpy (*cfg_file, line);
-#ifdef DEBUG
-                fprintf(stderr, "DEBUG: [%s] cfg_file specified: %s\n", __func__, *cfg_file);
-#endif
+                telem_debug("DEBUG: cfg_file specified: %s\n", *cfg_file);
         } else {
-#ifdef DEBUG
-                fprintf(stderr, "DEBUG: [%s] no user cfg file specified, cfg_prefix: %08x\n",
-                                __func__, cfg_prefix);
-#endif
+                telem_debug("DEBUG: no user cfg file specified, cfg_prefix: %08x\n", cfg_prefix);
                 *cfg_file = NULL;
                 rewind(fp);
         }

--- a/src/log.h
+++ b/src/log.h
@@ -42,8 +42,8 @@
 
 #ifdef DEBUG
 #define telem_debug(...) do { \
-                (telem_log(LOG_DEBUG, "%s():[%d]", __func__, __LINE__), \
-                 telem_log(LOG_DEBUG, __VA_ARGS__)); \
+                telem_log(LOG_DEBUG, "%s():[%d] ", __func__, __LINE__); \
+                telem_log(LOG_DEBUG, __VA_ARGS__); \
 } while (0);
 #else
 #define telem_debug(...) do {} while (0);

--- a/src/probes/hello.c
+++ b/src/probes/hello.c
@@ -90,7 +90,7 @@ static char *create_payload(unsigned options)
 
                 num_bundles = scandir("/usr/share/clear/bundles", &entries, nodots, alphasort);
                 if (num_bundles < 0) {
-                        telem_log(LOG_ERR, "scandir failed: %s\n", strerror(errno));
+                        telem_perror("scandir failed");
                         free(payload);
                         return NULL;
                 }

--- a/src/probes/klog_main.c
+++ b/src/probes/klog_main.c
@@ -51,7 +51,7 @@ int main(void)
         // Gets the size of the kernel ring buffer
         log_size = klogctl(SYSLOG_ACTION_SIZE_BUFFER, NULL, 0);
         if (log_size < 0) {
-                telem_log(LOG_ERR, "Cannot read size of kernel ring buffer: %s\n", strerror(errno));
+                telem_perror("Cannot read size of kernel ring buffer");
                 return 1;
         }
 
@@ -70,7 +70,7 @@ int main(void)
                 memset(bufp, 0, buflen);
                 bytes_read = klogctl(SYSLOG_ACTION_READ, bufp, (int)buflen);
                 if (bytes_read < 0) {
-                        telem_log(LOG_ERR, "Cannot read contents of kernel ring buffer: %s\n", strerror(errno));
+                        telem_perror("Cannot read contents of kernel ring buffer");
                         return 1;
                 }
 

--- a/src/probes/klog_scanner.c
+++ b/src/probes/klog_scanner.c
@@ -91,10 +91,8 @@ void split_buf_by_line(char *bufp, int bytes)
                         start[linelength] = '\0';
                         parse_single_line(start, linelength);
                         if (oops_processed == true) {
-                        #ifdef DEBUG
-                            printf("[%s] oops_processed detected !\n", __func__);
-                        #endif
-                            break;
+                                telem_debug("oops_processed detected !\n");
+                                break;
                         }
                         linelength = 0;
                 }
@@ -136,16 +134,14 @@ void klog_process_oops_msgs(struct oops_log_msg *msg)
 
         struct oops_log_msg oops_msg;
         if (handle_entire_oops(contents, (long)size, &oops_msg)) {
-            #ifdef DEBUG
-                printf("Raw message:\n");
+#ifdef DEBUG
+                telem_debug("DEBUG: Raw oops message:\n");
                 for (int i = 0; i < oops_msg.length; i++) {
-                        printf("%s\n", oops_msg.lines[i]);
+                        telem_log(LOG_DEBUG, "%s\n", oops_msg.lines[i]);
                 }
-            #endif
+#endif
                 payload = parse_payload(&oops_msg);
-            #ifdef DEBUG
-                printf("Payload Parsed :%s\n", payload->str);
-            #endif
+                telem_debug("DEBUG: Payload Parsed :%s\n", payload->str);
                 oops_msg_cleanup(&oops_msg);
                 send_data(payload->str, (char *)oops_msg.pattern->classification, (uint32_t)oops_msg.pattern->severity);
                 nc_string_free(payload);

--- a/src/probes/pstore_clean.c
+++ b/src/probes/pstore_clean.c
@@ -132,7 +132,7 @@ int main(int argc, char **argv)
         if (mkdir(MOUNT, 0755) < 0) {
                 //If there is an error other than an existing directory
                 if (errno != EEXIST) {
-                        telem_log(LOG_ERR, "Error creating directory /dev/pstore : %s\n", strerror(errno));
+                        telem_perror("Error creating directory /dev/pstore");
                         //bail out?
                         exit(EXIT_FAILURE);
                 }

--- a/src/probes/pstore_probe.c
+++ b/src/probes/pstore_probe.c
@@ -65,14 +65,12 @@ void handle_complete_oops_message(struct oops_log_msg *msg)
 
 #ifdef DEBUG
         for (int i = 0; i < msg->length; i++) {
-                printf("%s\n", msg->lines[i]);
+                telem_debug("DEBUG: %s\n", msg->lines[i]);
         }
 #endif
         payload = parse_payload(msg);
 
-#ifdef DEBUG
-        printf("Payload Parsed :%s\n", payload->str);
-#endif
+        telem_debug("DEBUG: Payload Parsed :%s\n", payload->str);
         send_data(payload->str, (char *)msg->pattern->classification, (uint32_t)msg->pattern->severity);
         nc_string_free(payload);
 }
@@ -232,9 +230,7 @@ int main(int argc, char **argv)
                 // Look for only dmesg logs. Ignore other types of pstore dumps for now.
                 if (sscanf(entry->d_name, "dmesg-efi-%" PRIu64, &id) == 1) {
                         parse_id(id, &count, &part);
-                        #ifdef DEBUG
-                        printf("Extracted count :%d, part : %d\n", count, part);
-                        #endif
+                        telem_debug("DEBUG: Extracted count :%d, part : %d\n", count, part);
                 } else {
                         continue;
                 }
@@ -262,9 +258,7 @@ int main(int argc, char **argv)
 
         nc_hashmap_iter_init(hash, &iter);
         while (nc_hashmap_iter_next(&iter, (void **)&key, (void **)&value)) {
-                #ifdef DEBUG
-                printf("Count in the hash: %d\n", NC_UNHASH_KEY(key));
-                #endif
+                telem_debug("DEBUG: Count in the hash: %d\n", NC_UNHASH_KEY(key));
 
                 head = (struct chunk_list *)value;
                 elem = head;

--- a/src/spool.c
+++ b/src/spool.c
@@ -244,9 +244,7 @@ void transmit_spooled_record(char *record_path, bool *post_succeeded, long size)
                         goto read_error;
                 }
                 strcpy (cfg_file, line);
-#ifdef DEBUG
-                fprintf(stderr, "DEBUG: [%s] cfg_file: %s\n", __func__, cfg_file);
-#endif
+                telem_debug("DEBUG: cfg_file: %s\n", cfg_file);
         } else {
                 cfg_file = NULL;
                 rewind(fp);

--- a/src/telemdaemon.c
+++ b/src/telemdaemon.c
@@ -165,7 +165,7 @@ bool handle_client(TelemDaemon *daemon, nfds_t ind, client *cl)
                         cl->offset = 0;
                         cl->size = RECORD_SIZE_LEN;
                         processed = true;
-                        telem_log(LOG_DEBUG, "Record processed for client %d\n", cl->fd);
+                        telem_debug("DEBUG: Record processed for client %d\n", cl->fd);
                         break;
                 }
         } while (len > 0);
@@ -252,11 +252,9 @@ static void stage_record(char *filepath, char *headers[], char *body, char *cfg_
         int tmpfd;
         FILE *tmpfile = NULL;
 
-#ifdef DEBUG
-        fprintf(stderr, "DEBUG: [%s] filepath:%s\n",__func__, filepath);
-        fprintf(stderr, "DEBUG: [%s] body:%s\n",__func__, body);
-        fprintf(stderr, "DEBUG: [%s] cfg:%s\n",__func__, cfg_file);
-#endif
+        telem_debug("DEBUG: filepath:%s\n", filepath);
+        telem_debug("DEBUG: body:%s\n", body);
+        telem_debug("DEBUG: cfg:%s\n", cfg_file);
         // Use default path if not provided
         if (filepath == NULL) {
                 telem_log(LOG_ERR, "filepath value must be provided, aborting\n");
@@ -328,20 +326,16 @@ void process_record(TelemDaemon *daemon, client *cl)
 
                 cfg_file = cfg + CFG_PREFIX_LENGTH;
                 cfg_info_size = CFG_PREFIX_LENGTH + strlen(cfg_file) + 1;
-#ifdef DEBUG
-                fprintf(stderr, "DEBUG: [%s] cfg_file: %s\n", __func__, cfg_file);
-#endif
+                telem_debug("DEBUG: cfg_file: %s\n", cfg_file);
         }
 
         buf += cfg_info_size;
         header_size = *(uint32_t *)buf;
         message_size = cl->size - (cfg_info_size + header_size);
-#ifdef DEBUG
-        fprintf(stderr, "DEBUG: [%s] cl->size: %zu\n", __func__, cl->size);
-        fprintf(stderr, "DEBUG: [%s] header_size: %zu\n", __func__, header_size);
-        fprintf(stderr, "DEBUG: [%s] message_size: %zu\n", __func__, message_size);
-        fprintf(stderr, "DEBUG: [%s] cfg_info_size: %zu\n", __func__, cfg_info_size);
-#endif
+        telem_debug("DEBUG: cl->size: %zu\n", cl->size);
+        telem_debug("DEBUG: header_size: %zu\n", header_size);
+        telem_debug("DEBUG: message_size: %zu\n", message_size);
+        telem_debug("DEBUG: cfg_info_size: %zu\n", cfg_info_size);
         assert(message_size > 0);      //TODO:Check for min and max limits
         msg = (char *)buf + sizeof(uint32_t);
 

--- a/src/telempostdaemon.c
+++ b/src/telempostdaemon.c
@@ -234,10 +234,7 @@ bool post_record_http(char *headers[], char *body, char *cfg)
                        goto Done;
                 }
                 reload_config();
-#ifdef DEBUG
-                fprintf(stderr, "DEBUG: override server_addr:%s\n", __func__,
-                        server_addr_config());
-#endif
+                telem_debug("DEBUG: override server_addr:%s\n", server_addr_config());
         }
 
         // Initialize the libcurl global environment once per POST. This lets us
@@ -325,10 +322,7 @@ Done:
                         res = 1;
                 }
                 reload_config();
-#ifdef DEBUG
-                fprintf(stderr, "DEBUG: restored server_addr:%s\n",
-                        __func__, server_addr_config());
-#endif
+                telem_debug("DEBUG: restored server_addr:%s\n", server_addr_config());
         }
 
         return res ? false : true;
@@ -546,9 +540,7 @@ bool process_staged_record(char *filename, bool is_retry, TelemPostDaemon *daemo
 
         /** Record delivery **/
         if (!daemon->record_server_delivery_enabled) {
-#ifdef DEBUG
-                telem_log(LOG_WARNING, "record server delivery disabled\n");
-#endif
+                telem_log(LOG_INFO, "record server delivery disabled\n");
                 // Not an error condition
                 ret = true;
                 goto end_processing_file;
@@ -556,9 +548,7 @@ bool process_staged_record(char *filename, bool is_retry, TelemPostDaemon *daemo
 
         /** Spool policies **/
         if (inside_direct_spool_window(daemon, time(NULL))) {
-#ifdef DEBUG
                 telem_log(LOG_INFO, "process_record: delivering directly to spool\n");
-#endif
                 /* Check spool max size conf */
                 max_spool_size = spool_max_size_config();
                 if (max_spool_size != -1 &&

--- a/src/util.c
+++ b/src/util.c
@@ -33,6 +33,7 @@
 
 #include "common.h"
 #include "util.h"
+#include "log.h"
 
 bool get_header(const char *haystack, const char *needle, char **line)
 {
@@ -100,10 +101,7 @@ long get_directory_size(const char *dir_path)
         dir = opendir(dir_path);
         if (!dir) {
                 ret = -errno;
-#ifdef DEBUG
-                fprintf(stderr, "ERR: Error opening spool dir: %s\n",
-                        strerror(errno));
-#endif
+                telem_perror("Error opening spool dir");
                 return ret;
         }
 
@@ -113,19 +111,15 @@ long get_directory_size(const char *dir_path)
                 }
                 ret = asprintf(&file_path, "%s/%s", dir_path, de->d_name);
                 if (ret < 0) {
-#ifdef DEBUG
-                        fprintf(stderr, "CRIT: Cannot allocate memory\n");
-#endif
+                        telem_log(LOG_CRIT, "CRIT: Cannot allocate memory\n");
                         closedir(dir);
                         return -ENOMEM;
                 }
 
                 ret = lstat(file_path, &buf);
                 if (ret < 0) {
-#ifdef DEBUG
-                        fprintf(stderr, "ERR: Could not stat file %s: %s\n",
+                        telem_log(LOG_ERR, "Could not stat file %s: %s\n",
                                 file_path, strerror(errno));
-#endif
                 } else {
                         total_size += (buf.st_blocks * 512);
                 }
@@ -204,9 +198,7 @@ int validate_classification(char *classification)
         }
 
         if (slashes != 2) {
-#ifdef DEBUG
-                fprintf(stderr, "ERR: Classification string should have two /s.\n");
-#endif
+                telem_log(LOG_ERR, "Classification string should have two /s.\n");
                 return 1;
         }
 


### PR DESCRIPTION
Avoid using printf and fprintf to log errors and information. Instead, use our telem_log, telem_debug, and telem_perror macros. The exception to this is command line based utilities where printing to stderr and stdout is almost always correct.

By using the telem_debug macro we can stop wrapping debug messages in #ifdef statements, as that's already handled by the macro.

Also remove many #ifdef DEBUG statements that were hiding legitimate error messages. If an error occurs it should be shown.