### PR TITLE
Protect security checks from removal

### DIFF
--- a/build-aux/make/cflags.make
+++ b/build-aux/make/cflags.make
@@ -12,7 +12,10 @@ AM_CFLAGS = \
 	-Wunreachable-code \
 	-funsigned-char \
 	-fPIE \
-	-fPIC
+	-fPIC \
+	-fno-strict-overflow \
+	-fno-delete-null-pointer-checks \
+	-fwrapv
 
 AM_CPPFLAGS = \
 	-D_FORTIFY_SOURCE=2 \


### PR DESCRIPTION
Compiler optimization can remove certain security checks for undefined
behavior. Add compiler flags that restrict arbitrary decisions when
handling undefined behaviors.

* fno-strict-overflow, do not assume signed overflow does not occur.
* fno-delete-null-pointer-checks, do not assume null pointer deference
does not exists.
* fwrapv, always wrap signed overflow.

Signed-off-by: Alex Jaramillo <alex.jch@gmail.com>