### PR TITLE
journal.c: reduce severity of message when failing to opening old rec…

### DIFF
--- a/src/journal/journal.c
+++ b/src/journal/journal.c
@@ -417,7 +417,7 @@ static void print_record(char *record_id)
 
         recordfp = fopen(filepath, "r");
         if (!recordfp) {
-                telem_perror("Error when opening a record to print");
+                telem_log(LOG_INFO, "Could not open record %s: %s\n", record_id, strerror(errno));
                 return;
         }
 


### PR DESCRIPTION
…ords

The default configuration for telemetry is to not store records that
were successfully sent. This would result in a multitude of errors when
calling the journal program with --include_record, as the records no
longer existed to open.

Signed-off-by: California Sullivan <california.l.sullivan@intel.com>