### PR TITLE
Fix compiler warnings [-Wstringop-truncation]

### DIFF
--- a/src/probes/klog_scanner.c
+++ b/src/probes/klog_scanner.c
@@ -126,7 +126,8 @@ void klog_process_oops_msgs(struct oops_log_msg *msg)
                 //Add the newline character to the end of each line
                 line = msg->lines[i];
                 linelength = strlen(line);
-                strncpy(bp, line, linelength);
+                // Copy the line (without the terminating NULL)
+                memcpy(bp, line, linelength);
                 bp[linelength] = '\n';
                 done += linelength + 1;
                 bp = contents + done;

--- a/src/telemetry.c
+++ b/src/telemetry.c
@@ -1003,16 +1003,12 @@ int tm_set_payload(struct telem_ref *t_ref, char *payload)
                 return -EINVAL;
         }
 
-        t_ref->record->payload = (char *)malloc(sizeof(char) * payload_len + 1);
+        t_ref->record->payload = strdup(payload);
 
         if (!t_ref->record->payload) {
                 telem_log(LOG_CRIT, "CRIT: Out of memory\n");
                 return -ENOMEM;
         }
-
-        memset(t_ref->record->payload, 0, sizeof(char) * payload_len + 1);
-
-        strncpy((char *)(t_ref->record->payload), (char *)payload, payload_len);
 
         t_ref->record->payload_size = payload_len;
 


### PR DESCRIPTION
Modify code to avoid generating compiler warning such as:
warning: ‘__builtin_strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>