### PR TITLE
check_probes.c: fix for compiler warning [-Wstringop-overflow=]

### DIFF
--- a/tests/check_probes.c
+++ b/tests/check_probes.c
@@ -29,14 +29,17 @@
 #include "src/probes/klog_scanner.h"
 #include "src/probes/oops_parser.h"
 
-char reason[1024];
-nc_string *bt;
-nc_string *pl;
+static char reason[1024];
+static nc_string *pl;
 
 void callback_func(struct oops_log_msg *msg)
 {
-        strncpy(reason, msg->lines[0], strlen(msg->lines[0]) + 1);
-
+        size_t len = strlen(msg->lines[0]) + 1;
+        if (len > sizeof(reason)) {
+                len = sizeof(reason);
+        }
+        memcpy(reason, msg->lines[0], len);
+        reason[sizeof(reason) - 1] = 0;
         pl = parse_payload(msg);
 }
 


### PR DESCRIPTION
Replaced strncpy with memcpy and added some buffer overflow checks in
order to avoid GCC9 compiler warning:
warning: ‘__builtin___strncpy_chk’ specified bound depends on the length of the source argument [-Wstringop-overflow=]

While in there, removed one unused global variable and declared the remaining
global variables as static.

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>