### PR TITLE
telem_record_gen.c: fix for compiler warning [-Wstringop-overflow=]

### DIFF
--- a/src/probes/telem_record_gen.c
+++ b/src/probes/telem_record_gen.c
@@ -272,7 +272,9 @@ static void get_payload_from_opt(char **payload)
         if (len >= MAX_PAYLOAD_LENGTH) {
                 len = MAX_PAYLOAD_LENGTH - 1;
         }
-        strncpy(*payload, opt_payload, len);
+
+        /* "payload" is pre-allocated zeroed buffer of MAX_PAYLOAD_LENGTH */
+        memcpy(*payload, opt_payload, len);
 }
 
 static void get_payload_from_stdin(char **payload)


### PR DESCRIPTION
Replace strncpy with memcpy to avoid GCC9 warning:
warning: ‘__builtin___strncpy_chk’ specified bound depends on the length of the source argument [-Wstringop-overflow=]

There is no danger of overflow. The destination buffer is guaranteed to
be of MAX_PAYLOAD_LENGTH.

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>