### PR TITLE
Fix build for logtype=systemd

### DIFF
--- a/src/journal/local.mk
+++ b/src/journal/local.mk
@@ -5,5 +5,11 @@ bin_PROGRAMS += \
 	%D%/journal.c \
 	src/util.c \
 	src/common.c
+%C%_telem_journal_CFLAGS = \
+	$(AM_CFLAGS)
 
+if LOG_SYSTEMD
+%C%_telem_journal_CFLAGS += $(SYSTEMD_JOURNAL_CFLAGS)
+%C%_telem_journal_LDADD = $(SYSTEMD_JOURNAL_LIBS)
+endif
 # vim: filetype=automake tabstop=8 shiftwidth=8 noexpandtab

--- a/src/log.h
+++ b/src/log.h
@@ -1,7 +1,7 @@
 /*
  * This program is part of the Clear Linux Project
  *
- * Copyright 2015 Intel Corporation
+ * Copyright 2019 Intel Corporation
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms and conditions of the GNU Lesser General Public License, as
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <stdio.h>
+#include <errno.h>
 
 #include "config.h"
 
@@ -35,7 +36,6 @@
 #include <systemd/sd-journal.h>
 #endif
 #else
-#include <errno.h>
 #include <string.h>
 #include <syslog.h>
 #endif

--- a/src/probes/local.mk
+++ b/src/probes/local.mk
@@ -9,23 +9,47 @@ bin_PROGRAMS += \
 	%D%/bertprobe
 
 %C%_pythonprobe_SOURCES = %D%/python-probe.c
+%C%_pythonprobe_CFLAGS = $(AM_CFLAGS)
 %C%_pythonprobe_LDADD = $(top_builddir)/src/libtelemetry.la
 %C%_pythonprobe_LDFLAGS = \
 	$(AM_LDFLAGS) \
 	-pie
 
+if LOG_SYSTEMD
+if HAVE_SYSTEMD_JOURNAL
+%C%_pythonprobe_CFLAGS += $(SYSTEMD_JOURNAL_CFLAGS)
+%C%_pythonprobe_LDADD += $(SYSTEMD_JOURNAL_LIBS)
+endif
+endif
+
 %C%_hprobe_SOURCES = %D%/hello.c
 %C%_hprobe_LDADD = $(top_builddir)/src/libtelemetry.la
+%C%_hprobe_CFLAGS = $(AM_CFLAGS)
 %C%_hprobe_LDFLAGS = \
 	$(AM_LDFLAGS) \
 	-pie
 
+if LOG_SYSTEMD
+if HAVE_SYSTEMD_JOURNAL
+%C%_hprobe_CFLAGS += $(SYSTEMD_JOURNAL_CFLAGS)
+%C%_hprobe_LDADD += $(SYSTEMD_JOURNAL_LIBS)
+endif
+endif
+
 %C%_bertprobe_SOURCES = %D%/bert_probe.c \
 	src/nica/b64enc.c
+%C%_bertprobe_CFLAGS = $(AM_CFLAGS)
 %C%_bertprobe_LDADD = $(top_builddir)/src/libtelemetry.la
 %C%_bertprobe_LDFLAGS = \
         $(AM_LDFLAGS) \
         -pie
+
+if LOG_SYSTEMD
+if HAVE_SYSTEMD_JOURNAL
+%C%_bertprobe_CFLAGS += $(SYSTEMD_JOURNAL_CFLAGS)
+%C%_bertprobe_LDADD += $(SYSTEMD_JOURNAL_LIBS)
+endif
+endif
 
 %C%_telem_record_gen_SOURCES = %D%/telem_record_gen.c
 %C%_telem_record_gen_CFLAGS = \
@@ -34,6 +58,14 @@ bin_PROGRAMS += \
 %C%_telem_record_gen_LDFLAGS = \
 	$(AM_LDFLAGS) \
 	-pie
+
+if LOG_SYSTEMD
+if HAVE_SYSTEMD_JOURNAL
+%C%_telem_record_gen_CFLAGS += $(SYSTEMD_JOURNAL_CFLAGS)
+%C%_telem_record_gen_LDADD += $(SYSTEMD_JOURNAL_LIBS)
+endif
+endif
+
 
 %C%_pstoreclean_SOURCES = %D%/pstore_clean.c
 %C%_pstoreclean_CFLAGS = \
@@ -119,13 +151,6 @@ if HAVE_SYSTEMD_JOURNAL
 %C%_klogscanner_LDADD += \
         $(SYSTEMD_JOURNAL_LIBS)
 endif
-
-if HAVE_SYSTEMD_JOURNAL
-%C%_klogscanner_CFLAGS += \
-        $(SYSTEMD_JOURNAL_CFLAGS)
-%C%_klogscanner_LDADD += \
-        $(SYSTEMD_JOURNAL_LIBS)
-endif
 endif
 
 
@@ -149,6 +174,10 @@ bin_PROGRAMS += \
 %C%_journalprobe_LDFLAGS = \
 	$(AM_LDFLAGS) \
 	-pie
+if LOG_SYSTEMD
+%C%_journalprobe_CFLAGS += $(SYSTEMD_JOURNAL_CFLAGS)
+%C%_journalprobe_LDADD += $(SYSTEMD_JOURNAL_LIBS)
+endif
 endif
 endif
 

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -33,6 +33,13 @@ dist_check_SCRIPTS = \
 	@CHECK_LIBS@ \
 	$(top_builddir)/src/libtelem-shared.la
 
+if HAVE_SYSTEMD_JOURNAL
+if LOG_SYSTEMD
+%C%_check_config_CFLAGS += $(SYSTEMD_JOURNAL_CFLAGS)
+%C%_check_config_LDADD += $(SYSTEMD_JOURNAL_LIBS)
+endif
+endif
+
 %C%_check_probd_SOURCES = \
 	%D%/check_probd.c \
 	src/telemdaemon.c \
@@ -180,6 +187,13 @@ EXTRA_DIST += \
 %C%_check_journal_LDADD = \
 	@CHECK_LIBS@
 
+if HAVE_SYSTEMD_JOURNAL
+if LOG_SYSTEMD
+%C%_check_journal_CFLAGS += $(SYSTEMD_JOURNAL_CFLAGS)
+%C%_check_journal_LDADD += $(SYSTEMD_JOURNAL_LIBS)
+endif
+endif
+
 %C%_check_libtelemetry_SOURCES = \
 	%D%/check_libtelemetry.c \
 	src/configuration.h \
@@ -194,5 +208,12 @@ EXTRA_DIST += \
 	@CHECK_LIBS@ \
 	$(top_builddir)/src/libtelemetry.la \
 	$(top_builddir)/src/libtelem-shared.la
+
+if HAVE_SYSTEMD_JOURNAL
+if LOG_SYSTEMD
+%C%_check_libtelemetry_CFLAGS += $(SYSTEMD_JOURNAL_CFLAGS)
+%C%_check_libtelemetry_LDADD += $(SYSTEMD_JOURNAL_LIBS)
+endif
+endif
 
 # vim: filetype=automake tabstop=8 shiftwidth=8 noexpandtab


### PR DESCRIPTION
Build is broken for multiple binaries when configured for logging
to systemd journal:

$ ./configure --enable-logtype=systemd
$ make

All binaries that use the routine "telem_log" must link to additional
libraries when logging to systemd journal.

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>