### PR TITLE
man pages: remove references to telemd

### DIFF
--- a/docs/man/telem-record-gen.1
+++ b/docs/man/telem-record-gen.1
@@ -89,7 +89,7 @@ Event id to use in the record. If not provided a randomly generated id will be a
 .SH SEE ALSO
 .INDENT 0.0
 .IP \(bu 2
-\fBtelemd\fP(1)
+\fBtelemprobd\fP(1)
 .IP \(bu 2
 \fI\%https://github.com/clearlinux/telemetrics\-client\fP
 .IP \(bu 2

--- a/docs/man/telem-record-gen.1.rst
+++ b/docs/man/telem-record-gen.1.rst
@@ -76,6 +76,6 @@ RETURN VALUES
 SEE ALSO
 ========
 
-* ``telemd``\(1)
+* ``telemprobd``\(1)
 * https://github.com/clearlinux/telemetrics-client
 * https://clearlinux.org/documentation/

--- a/docs/man/telemctl.1
+++ b/docs/man/telemctl.1
@@ -66,7 +66,7 @@ Checks if telemetry client daemons are active (telemprobd and telempostd).
 .SH SEE ALSO
 .INDENT 0.0
 .IP \(bu 2
-\fBtelemd\fP(1)
+\fBtelemprobd\fP(1)
 .IP \(bu 2
 \fI\%https://github.com/clearlinux/telemetrics\-client\fP
 .IP \(bu 2

--- a/docs/man/telemctl.1.rst
+++ b/docs/man/telemctl.1.rst
@@ -52,6 +52,6 @@ RETURN VALUES
 SEE ALSO
 ========
 
-* ``telemd``\(1)
+* ``telemprobd``\(1)
 * https://github.com/clearlinux/telemetrics-client
 * https://clearlinux.org/documentation/

--- a/docs/man/telemetry.3
+++ b/docs/man/telemetry.3
@@ -60,7 +60,7 @@ The function \fBtm_set_payload()\fP attaches the provided telemetry record
 data to the telemetry record. The current maximum payload size is 8192b.
 .sp
 The function \fBtm_send_record()\fP delivers the record to the local
-\fBtelemd\fP(1) service.
+\fBtelemprobd\fP(1) service.
 .sp
 The function \fBtm_set_config_file()\fP can be used to provide an alternate
 configuration path to the telemetry library.

--- a/docs/man/telemetry.3.rst
+++ b/docs/man/telemetry.3.rst
@@ -44,7 +44,7 @@ The function ``tm_set_payload()`` attaches the provided telemetry record
 data to the telemetry record. The current maximum payload size is 8192b.
 
 The function ``tm_send_record()`` delivers the record to the local
-``telemd``\(1) service.
+``telemprobd``\(1) service.
 
 The function ``tm_set_config_file()`` can be used to provide an alternate
 configuration path to the telemetry library.


### PR DESCRIPTION
"telemd" was replaced by "telemprobd" a long time
ago, however several man pages still contain refererences
to "telemd".
This patch replaces all references accordingly.

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>