### PR TITLE
Add "ACPI Error:" pattern for ACPI issues.

### DIFF
--- a/src/probes/oops_parser.c
+++ b/src/probes/oops_parser.c
@@ -150,6 +150,12 @@ struct oops_pattern oops_patterns_arr[] = {
                 TM_MEDIUM,
                 false,
         },
+        {
+                "ACPI Error:",
+                "org.clearlinux/kernel/warning",
+                TM_MEDIUM,
+                false,
+        },
 };
 
 static int oops_patterns_cnt = sizeof(oops_patterns_arr) / sizeof(struct oops_pattern);


### PR DESCRIPTION
If "ACPI Error:" happen, it means there is kernel or bios issue.

Signed-off-by: Ammy Yi <ammy.yi@intel.com>