### PR TITLE
telem_record_gen.c: return correct error in instanciate_record

### DIFF
--- a/src/probes/telem_record_gen.c
+++ b/src/probes/telem_record_gen.c
@@ -335,8 +335,10 @@ static int instanciate_record(struct telem_ref **t_ref, char *payload)
                 goto out1;
         }
 
-        if ((ret = opt_event_id && tm_set_event_id(*t_ref, opt_event_id)) < 0) {
-                goto out1;
+        if (opt_event_id) {
+                if ((ret = tm_set_event_id(*t_ref, opt_event_id)) < 0) {
+                        goto out1;
+                }
         }
 
         if ((ret = tm_set_payload(*t_ref, payload)) < 0) {


### PR DESCRIPTION
In the routine "instanciate_record":
If the user passed event_id on the command line and it was incorrect,
any returned error from tm_set_event was ignored and "instanciate_record"
could return success (0).

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>