### PR TITLE
telemdaemon.c: don't assume correct machine_id length

### DIFF
--- a/src/telemdaemon.c
+++ b/src/telemdaemon.c
@@ -430,7 +430,7 @@ bool get_machine_id(char *machine_id)
                 return false;
         }
 
-        ret = fscanf(id_file, "%s", machine_id);
+        ret = fscanf(id_file, "%32s", machine_id);
         if (ret != 1) {
                 telem_perror("Could not read machine id from file");
                 fclose(id_file);


### PR DESCRIPTION
"fscanf" assumes an arbitrarily long string, so limit the scan to
32 characters to avoid a potential buffer overflow.

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>