### PR TITLE
util.c: correct return value from "get_header_value"

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -65,7 +65,7 @@ bool get_header_value(const char *header, char **value)
                 *value = strdup(sep);
         }
 
-        return (bool)(value != NULL);
+        return (bool)(*value != NULL);
 }
 
 void *reallocate(void **addr, size_t *allocated, size_t requested)


### PR DESCRIPTION
Even if errors were encounterd parsing the header we used to
return success ("true") by a mistake.
Fix this by correcting the test.

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>