### PR TITLE
oops_parser.c: remove unneeded check

### DIFF
--- a/src/probes/oops_parser.c
+++ b/src/probes/oops_parser.c
@@ -475,7 +475,7 @@ static void stack_frame_append(struct stack_frame **head, struct stack_frame **t
                 while (*start && !isspace(*start)) {
                         start++;
                 }
-                if (start && *start == '\0') {
+                if (*start == '\0') {
                         return;
                 }
 


### PR DESCRIPTION
Remove a useless test.
Routine "stack_frame_append": don't test again if a pointer
is NULL. It has been done already. Also, the pointer was
already dereferenced before the test.

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>