### PR TITLE
oops_parser.c: detect kernel panic

### DIFF
--- a/src/probes/oops_parser.c
+++ b/src/probes/oops_parser.c
@@ -156,6 +156,12 @@ struct oops_pattern oops_patterns_arr[] = {
                 TM_MEDIUM,
                 false,
         },
+        {
+                "Kernel panic - not syncing:",
+                "org.clearlinux/kernel/panic",
+                TM_CRITICAL,
+                false,
+        },
 };
 
 static int oops_patterns_cnt = sizeof(oops_patterns_arr) / sizeof(struct oops_pattern);


### PR DESCRIPTION
Add pattern for kernel panic. The new pattern can be tested with:

  $ sudo sh -c "echo 'c' > /proc/sysrq-trigger"

The above command will crash the system immediately, however upon reboot
the pstoreprobe will send the crah report.

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>