### PR TITLE
oops_parser.c: remove unneded check

### DIFF
--- a/src/probes/oops_parser.c
+++ b/src/probes/oops_parser.c
@@ -516,7 +516,7 @@ static void stack_frame_append(struct stack_frame **head, struct stack_frame **t
                 while (*start && !isspace(*start)) {
                         start++;
                 }
-                if (start && *start == '\0') {
+                if (*start == '\0') {
                         return;
                 }
 


### PR DESCRIPTION
Remove a test for a valid pointer. The test hase been done
already. Also the pointer has been dereferenced already.

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>