### PR TITLE
journal.c: deserialize_journal_entry fixes

### DIFF
--- a/src/journal/journal.c
+++ b/src/journal/journal.c
@@ -99,11 +99,14 @@ static int deserialize_journal_entry(char *line, struct JournalEntry **entry)
         size_t offset = 0;
         struct JournalEntry *e = NULL;
 
+        /* Assume an error... */
+        *entry = NULL;
+
         if (line == NULL || !strlen(line)) {
                 return -1;
         }
 
-        e = malloc(sizeof(struct JournalEntry));
+        e = calloc(1, sizeof(struct JournalEntry));
         if (!e) {
                 return -1;
         }
@@ -138,10 +141,6 @@ static int deserialize_journal_entry(char *line, struct JournalEntry **entry)
                                         e->boot_id = out;
                                         rc = 0;
                                         break;
-                                default:
-                                        assert(i < 0 && i > 4);
-                                        free(out);
-                                        rc = 1;
                         }
                 } else {
                         rc = -1;


### PR DESCRIPTION
1. Return a known (NULL) value of "*entry" if the function fails.
2. Remove some dead code. Since the loop index ranges 0..4, it is
   pointless to have a switch statement outsized of this range.
3. Ensure all pointers within the allocated structure JournalEntry
   are defined. (They are initialized as NULL courtesy of calloc),
   otherwise we may end up freeing some random pointers in
   "free_journal_entry"

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>