### PR TITLE
telem-record-gen enable print message

### DIFF
--- a/src/iorecord.c
+++ b/src/iorecord.c
@@ -43,7 +43,7 @@ bool _fgets(char *s, int n, FILE *stream)
 
 bool read_record(char *fullpath, char *headers[], char **body, char **cfg_file)
 {
-        int i, ret = 0;
+        int i = 0;
         bool result = false;
         FILE *fp = NULL;
         long offset;

--- a/src/probes/telem_record_gen.c
+++ b/src/probes/telem_record_gen.c
@@ -370,6 +370,9 @@ static int send_record(char *payload)
         }
 
         if ((ret = tm_send_record(t_ref)) < 0) {
+                if (ret == -ECONNREFUSED) {
+                        fprintf(stdout, "Unable to send record make sure to opt-in to telemetry first 'telemctl opt-in'\n");
+                }
                 goto out;
         }
 

--- a/src/probes/telem_record_gen.c
+++ b/src/probes/telem_record_gen.c
@@ -371,7 +371,7 @@ static int send_record(char *payload)
 
         if ((ret = tm_send_record(t_ref)) < 0) {
                 if (ret == -ECONNREFUSED) {
-                        fprintf(stdout, "Unable to send record make sure to opt-in to telemetry first 'telemctl opt-in'\n");
+                        fprintf(stderr, "Unable to send record. Make sure to opt-in to telemetry first 'telemctl opt-in'\n");
                 }
                 goto out;
         }

--- a/src/telemetry.c
+++ b/src/telemetry.c
@@ -913,14 +913,6 @@ int tm_create_record(struct telem_ref **t_ref, uint32_t severity,
                      char *classification, uint32_t payload_version)
 {
         int ret = 0;
-        int k = 0;
-        struct stat unused;
-
-        k = stat(TM_OPT_OUT_FILE, &unused);
-        if (k == 0) {
-                // Bail early if opt-out is enabled
-                return -ECONNREFUSED;
-        }
 
         *t_ref = (struct telem_ref *)malloc(sizeof(struct telem_ref));
         if (*t_ref == NULL) {
@@ -984,14 +976,6 @@ int tm_set_payload(struct telem_ref *t_ref, char *payload)
 {
         size_t payload_len;
         int ret = 0;
-        int k = 0;
-        struct stat unused;
-
-        k = stat(TM_OPT_OUT_FILE, &unused);
-        if (k == 0) {
-                // Bail early if opt-out is enabled
-                return -ECONNREFUSED;
-        }
 
         payload_len = strlen((char *)payload);
 


### PR DESCRIPTION
Currently if telemetry is opt-out telem-record-gen is unable to print a telemetry message even when no message delivery takes place. This change enables to create messages for printing to stdout.