### PR TITLE
telem_recoder_gen.c: remove redundant if statement

### DIFF
--- a/src/probes/telem_record_gen.c
+++ b/src/probes/telem_record_gen.c
@@ -353,9 +353,7 @@ static int instanciate_record(struct telem_ref **t_ref, char *payload)
                 }
         }
 
-        if ((ret = tm_set_payload(*t_ref, payload)) < 0) {
-                goto out1;
-        }
+        ret = tm_set_payload(*t_ref, payload);
 out1:
         return ret;
 }


### PR DESCRIPTION
Removed the last error test from routine "instanciate_record".

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>