### PR TITLE
telemdaemon.c: modify handle_client

### DIFF
--- a/src/telemdaemon.h
+++ b/src/telemdaemon.h
@@ -126,27 +126,6 @@ void remove_client(client_list_head *client_head, client *cl);
 bool is_client_list_empty(client_list_head *client_head);
 
 /**
- * Terminate a client connection
- *
- * @param daemon Pointer to the daemon
- * @param cl Pointer to the client in the client list
- * @param index The index of the client file descriptor in the poll fd
- *    array
- *
- */
-void terminate_client(TelemDaemon *daemon, client *cl, nfds_t index);
-
-/**
- * Process record from a client
- *
- * @param daemon Pointer to the daemon
- * @param cl Pointer to the client in the client list
- *
- * @return true on success, false on failure
- */
-void process_record(TelemDaemon *daemon, client *cl);
-
-/**
  * Get random machine id stored in file
  *
  * @return machine id stored in file if successfully read, 0 otherwise

--- a/src/telemetry.c
+++ b/src/telemetry.c
@@ -1256,8 +1256,8 @@ int tm_send_record(struct telem_ref *t_ref)
 
         /*
          * Allocating buffer for what we intend to send.  Buffer layout is:
-         * <uint32_t total_size>     : so recv knows how much to read
-         * <custom cfg file field>   : optional
+         * <uint32_t record_size>     : so recv knows how much to read
+         * <custom cfg file field>    : optional
          * <uint32_t header_size>
          * <headers + Payload>
          * <null-byte>
@@ -1265,16 +1265,14 @@ int tm_send_record(struct telem_ref *t_ref)
          */
         record_size = (2 * sizeof(uint32_t)) + total_size + 1;
 
-        data = malloc(record_size);
+        data = calloc(sizeof(char), record_size);
         if (!data) {
                 telem_log(LOG_CRIT, "CRIT: Out of memory\n");
                 close(sfd);
                 return -ENOMEM;
         }
 
-        memset(data, 0, record_size);
-
-        memcpy(data, &total_size, sizeof(uint32_t));
+        memcpy(data, &record_size, sizeof(uint32_t));
         offset += sizeof(uint32_t);
 
         if (cfg_file_name != NULL) {


### PR DESCRIPTION
Split a fairly convoluted loop in "handle_client" into
two distinct steps:

1. Read the record size by reading the first 4 bytes.
2. Once the record size is known, read the rest of the record
   into a buffer.

All the buffer for the record allocation/deallocations are handled
in this routine as well. The new code does not need to know any datails
about the record buffer layout. This needed a minor modification of the
record itself, the first 4 bytes of the record now contain the length of
the entire record (including the 4 bytes). This required a minor change
in "telemtry.c" the routine tm_send_record. The previous "total_size"
in the 4 bytes did not include the terminator and header_size, so
"handle_client" needed to adjust for those to get the real expected
record size.

Also declared "terminate_client" and "process_record" as static.

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>