### PR TITLE
crash_probe.c: improve error handling

### DIFF
--- a/src/probes/crash_probe.c
+++ b/src/probes/crash_probe.c
@@ -250,7 +250,7 @@ static int frame_cb(Dwfl_Frame *frame, void *userdata)
                                " current frame: %s\n",
                                dwfl_errmsg(-1));
                 if (ret < 0) {
-                        return DWARF_CB_ABORT;
+                        errorstr = NULL;
                 }
                 return DWARF_CB_ABORT;
         }


### PR DESCRIPTION
Routine frame_cb: if asprintf fails, assume destination string
is not initialized properly.

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>