### PR TITLE
configure.ac: bump version to 2.2.2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([telemetrics-client], [2.2.1], [https://clearlinux.org/])
+AC_INIT([telemetrics-client], [2.2.2], [https://clearlinux.org/])
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([1.14 -Wall -Werror -Wno-extra-portability foreign subdir-objects])
 AM_SILENT_RULES([yes])


### PR DESCRIPTION
Version bump from 2.2.1 to 2.2.2

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>