### PR TITLE
Enable cl telemetry build in android system

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,0 +1,157 @@
+
+LOCAL_PATH := $(call my-dir)
+
+TELEM_PATH := $(LOCAL_PATH)
+IN_PATH = $(TELEM_PATH)/configure.ac
+
+LOCAL_DEPENDENCY_HEAD := \
+	$(LOCAL_PATH)/src/log.h
+
+DATA_DIR := ""
+BACK_END_ADDR := ""
+LSTATE_DIR := "/data/vendor/telemetrics"
+
+############################################
+#Build telemetrics library: libtelem_shared#
+############################################
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := libtelem_shared
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_OWNER := intel
+LOCAL_MODULE_CLASS := SHARED_LIBRARIES
+LOCAL_PROPRIETARY_MODULE := true
+LOCAL_SRC_FILES := \
+	src/util.c \
+	src/configuration.c \
+	src/nica/inifile.c \
+	src/nica/hashmap.c \
+	src/nica/b64enc.c \
+	src/common.c
+
+LOCAL_C_INCLUDES := \
+	$(LOCAL_PATH) \
+	$(LOCAL_PATH)/src \
+	$(LOCAL_PATH)/src/nica
+
+LOCAL_SHARED_LIBRARIES := \
+	libc \
+	libcutils
+
+GEN := $(local-generated-sources-dir)/config_android.h
+$(GEN): GEN_TOOL := $(shell $(TELEM_PATH)/android_config_gen.sh $(IN_PATH))
+$(GEN): $(GEN_TOOL)
+	$(transform-generated-source)
+
+LOCAL_GENERATE_SOURCE += $(GEN)
+LOCAL_LDLIBS := -llog
+LOCAL_CFLAGS += -Wno-unused-parameter
+LOCAL_CFLAGS += -DDATADIR='$(DATA_DIR)' \
+    -DBACKEND_ADDR='$(BACK_END_ADDR)' \
+    -DLOCALSTATEDIR='$(LSTATE_DIR)'
+$(LOCAL_MODULE): $(LOCAL_DEPENDENCY_HEAD)
+
+include $(BUILD_SHARED_LIBRARY)
+
+#########################################
+#Build telemetrics library: libtelemetry#
+#########################################
+include $(CLEAR_VARS)
+LOCAL_MODULE := libtelemetry
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_OWNER := intel
+LOCAL_PROPRIETARY_MODULE := true
+LOCAL_SRC_FILES := \
+	src/telemetry.c
+
+LOCAL_C_INCLUDES := \
+	$(LOCAL_PATH) \
+	$(LOCAL_PATH)/src
+
+LOCAL_SHARED_LIBRARIES := \
+	libtelem_shared
+
+LOCAL_LDLIBS := -llog
+LOCAL_CFLAGS += -Wno-unused-parameter -Wno-pointer-bool-conversion -Wno-unknown-warning-option -Wno-format
+$(LOCAL_MODULE): $(LOCAL_DEPENDENCY_HEAD)
+
+include $(BUILD_SHARED_LIBRARY)
+
+#########################################
+# Build the telemetry daemon: telemprobd#
+#########################################
+include $(CLEAR_VARS)
+LOCAL_MODULE := telemprobd
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_OWNER := intel
+LOCAL_PROPRIETARY_MODULE := true
+
+LOCAL_SRC_FILES := \
+	src/probe.c \
+	src/telemdaemon.c \
+	src/journal/journal.c
+
+LOCAL_C_INCLUDES := \
+	$(LOCAL_PATH) \
+	$(LOCAL_PATH)/src \
+	$(LOCAL_PATH)/src/journal
+
+LOCAL_SHARED_LIBRARIES := \
+	$(CURL_LIBS) \
+	libcurl \
+	libtelem_shared \
+	libtelemetry \
+	libc \
+	libcutils
+
+LOCAL_LDLIBS := -llog
+LOCAL_CFLAGS += -Wno-unused-parameter
+LOCAL_CFLAGS += -DLOCALSTATEDIR='$(LSTATE_DIR)'
+$(LOCAL_MODULE): $(LOCAL_DEPENDENCY_HEAD)
+
+include $(BUILD_EXECUTABLE)
+
+#########################################
+# Build the telemetry daemon: telempostd#
+#########################################
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := telempostd
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_OWNER := intel
+LOCAL_PROPRIETARY_MODULE := true
+
+LOCAL_SRC_FILES := \
+	src/post.c \
+	src/telempostdaemon.c \
+	src/journal/journal.c \
+	src/spool.c \
+	src/retention.c \
+	src/iorecord.c
+
+LOCAL_C_INCLUDES := \
+	$(LOCAL_PATH) \
+	$(LOCAL_PATH)/src \
+	$(LOCAL_PATH)/src/journal
+
+LOCAL_SHARED_LIBRARIES := \
+	$(CURL_LIBS) \
+	libcurl \
+	libtelem_shared \
+	libtelemetry \
+	libc \
+	libcutils
+
+LOCAL_LDLIBS := -llog
+LOCAL_CFLAGS += -Wno-unused-parameter -Wno-incompatible-pointer-types
+$(LOCAL_MODULE): $(LOCAL_DEPENDENCY_HEAD)
+
+include $(BUILD_EXECUTABLE)
+
+##############################
+# Build all telemetry probes #
+##############################
+ifeq ($(wildcard $(LOCAL_PATH)/src/probes/probes.mk),)
+else
+include $(LOCAL_PATH)/src/probes/probes.mk
+endif

--- a/android_config_gen.sh
+++ b/android_config_gen.sh
@@ -1,0 +1,27 @@
+#! /bin/bash
+
+echo "generate the config.h"
+VAR=$1;
+file="$(sed -n 's/^AC_CONFIG_HEADERS(\([^)]*\))/\1/p' $1 | tr -d '[]')"
+if [[ "$file" =~ ',' ]]; then
+	echo Error: Invalid file name: $file
+	exit 1
+fi
+
+if [[ "$file" = '' ]]; then
+	file="config.h"
+fi
+echo "${VAR%/*}/$file"
+cat > "${VAR%/*}/$file" << EOF
+#pragma once
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "$(sed -n 's/^AC_INIT([^,]\+,[ \t]*\([^,]*\).*)/\1/p' $1 | tr -d '[]')"
+
+inline int malloc_trim(int size) {return size;}
+
+/* qsort_r is not available in Android, so redefine it */
+inline void qsort_r(void *__base, size_t __nmemb, size_t __size,
+                    int * function, void *__arg) {}
+
+EOF

--- a/src/log.h
+++ b/src/log.h
@@ -96,4 +96,12 @@
 #define telem_perror(msg) fprintf(stderr, "ERROR: " msg ": %s\n", strerror(errno))
 #endif
 
+#ifndef telem_log
+#define telem_log(priority, ...) do {} while (0);
+#endif
+
+#ifndef telem_perror
+#define telem_perror(msg) do {} while (0);
+#endif
+
 /* vi: set ts=8 sw=8 sts=4 et tw=80 cino=(0: */

--- a/src/probes/probes.mk
+++ b/src/probes/probes.mk
@@ -1,0 +1,146 @@
+LOCAL_PATH := $(call my-dir)
+
+################
+# build hprobe #
+################
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := hprobe
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_OWNER := intel
+LOCAL_MODULE_CLASS := EXECUTABLES
+LOCAL_SHARED_LIBRARIES := libtelemetry
+LOCAL_LDLIBS := -llog
+LOCAL_CFLAGS += -Wno-unused-parameter
+LOCAL_SRC_FILES := \
+	hello.c
+
+LOCAL_C_INCLUDES := $(LOCAL_PATH) $(LOCAL_PATH)/.. $(LOCAL_PATH)/../..
+LOCAL_PROPRIETARY_MODULE := true
+$(LOCAL_MODULE): $(LOCAL_DEPENDENCY_HEAD)
+
+include $(BUILD_EXECUTABLE)
+
+##########################
+# build telem-record-gen #
+##########################
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := telem-record-gen
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_OWNER := intel
+LOCAL_MODULE_CLASS := EXECUTABLES
+LOCAL_SHARED_LIBRARIES := libtelemetry
+LOCAL_LDLIBS := -llog
+LOCAL_CFLAGS += -Wno-unused-parameter
+LOCAL_SRC_FILES := \
+	telem_record_gen.c
+
+LOCAL_C_INCLUDES := $(LOCAL_PATH) $(LOCAL_PATH)/.. $(LOCAL_PATH)/../..
+LOCAL_PROPRIETARY_MODULE := true
+$(LOCAL_MODULE): $(LOCAL_DEPENDENCY_HEAD)
+
+include $(BUILD_EXECUTABLE)
+
+#####################
+# build klogscanner #
+#####################
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := klogscanner
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_OWNER := intel
+LOCAL_MODULE_CLASS := EXECUTABLES
+LOCAL_SHARED_LIBRARIES := libtelemetry libtelem_shared
+LOCAL_LDFLAGS := $(AM_LDFLAGS) -pie
+LOCAL_LDLIBS := -llog
+LOCAL_CFLAGS += -Wno-unused-parameter -Wno-missing-field-initializers
+LOCAL_SRC_FILES := \
+	klog_main.c \
+	klog_scanner.c \
+	../nica/nc-string.c \
+	oops_parser.c
+
+LOCAL_C_INCLUDES := $(LOCAL_PATH) $(LOCAL_PATH)/.. $(LOCAL_PATH)/../..
+LOCAL_PROPRIETARY_MODULE := true
+$(LOCAL_MODULE): $(LOCAL_DEPENDENCY_HEAD)
+
+include $(BUILD_EXECUTABLE)
+
+#####################
+# build pstoreprobe #
+#####################
+
+pstoredir:="/sys/fs/pstore"
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := pstoreprobe
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_OWNER := intel
+LOCAL_MODULE_CLASS := EXECUTABLES
+LOCAL_SHARED_LIBRARIES := libtelemetry libtelem_shared
+LOCAL_CFLAGS += -DPSTOREDIR='$(pstoredir)'
+LOCAL_LDFLAGS := $(AM_LDFLAGS) -pie
+LOCAL_LDLIBS := -llog
+LOCAL_CFLAGS += -Wno-unused-parameter -Wno-missing-field-initializers
+LOCAL_SRC_FILES := \
+	pstore_probe.c \
+	../nica/nc-string.c \
+	oops_parser.c
+
+LOCAL_C_INCLUDES := $(LOCAL_PATH) $(LOCAL_PATH)/.. $(LOCAL_PATH)/../..
+LOCAL_PROPRIETARY_MODULE := true
+$(LOCAL_MODULE): $(LOCAL_DEPENDENCY_HEAD)
+
+include $(BUILD_EXECUTABLE)
+
+#####################
+# build pstoreclean #
+#####################
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := pstoreclean
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_OWNER := intel
+LOCAL_MODULE_CLASS := EXECUTABLES
+LOCAL_SHARED_LIBRARIES := libtelemetry libtelem_shared
+LOCAL_LDFLAGS := $(AM_LDFLAGS) -pie
+LOCAL_CFLAGS += -DPSTOREDIR='$(pstoredir)'
+LOCAL_LDLIBS := -llog
+LOCAL_CFLAGS += -Wno-unused-parameter
+LOCAL_SRC_FILES := \
+	pstore_clean.c
+
+LOCAL_C_INCLUDES := $(LOCAL_PATH) $(LOCAL_PATH)/.. $(LOCAL_PATH)/../..
+LOCAL_PROPRIETARY_MODULE := true
+$(LOCAL_MODULE): $(LOCAL_DEPENDENCY_HEAD)
+
+include $(BUILD_EXECUTABLE)
+
+###################
+# build bertprobe #
+###################
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := bertprobe
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_OWNER := intel
+LOCAL_MODULE_CLASS := EXECUTABLES
+LOCAL_SHARED_LIBRARIES := libtelemetry
+LOCAL_LDFLAGS := $(AM_LDFLAGS) -pie
+LOCAL_LDLIBS := -llog
+LOCAL_CFLAGS += -Wno-unused-parameter
+LOCAL_SRC_FILES := \
+	bert_probe.c \
+	../nica/b64enc.c
+
+LOCAL_C_INCLUDES := $(LOCAL_PATH) $(LOCAL_PATH)/.. $(LOCAL_PATH)/../..
+LOCAL_PROPRIETARY_MODULE := true
+$(LOCAL_MODULE): $(LOCAL_DEPENDENCY_HEAD)
+
+include $(BUILD_EXECUTABLE)


### PR DESCRIPTION
Add Android.mk to build libtelem-shared, libtelemetry, telemprobd and
telempostd in android system.
Add src/probes/probes.mk to build all probes in android.
Add android_config_gen.sh to generate config.h in android.
Fix building errors when porting cl telemetry to android.

Change-Id: Id14599df4b19a34410409e0b32ee032910435e25
Signed-off-by: Tian Baofeng <baofeng.tian@intel.com>
Signed-off-by: chenxia1 <xiao.x.chen@intel.com>