### PR TITLE
klog_scanner.c: truncate payload if needed

### DIFF
--- a/src/probes/klog_scanner.c
+++ b/src/probes/klog_scanner.c
@@ -23,6 +23,7 @@
 #include <unistd.h>
 #include <sys/stat.h>
 
+#include "common.h"
 #include "log.h"
 #include "oops_parser.h"
 #include "klog_scanner.h"
@@ -42,6 +43,11 @@ static bool send_data(char *backtrace, char *class, uint32_t severity)
                 telem_log(LOG_ERR, "Failed to create record: %s",
                           strerror(-ret));
                 return false;
+        }
+
+        /* Truncate payload if necessary, otherwise nothing will be sent */
+        if (strlen(backtrace) > MAX_PAYLOAD_LENGTH) {
+                backtrace[MAX_PAYLOAD_LENGTH-1] = 0;
         }
 
         if ((ret = tm_set_payload(handle, backtrace)) < 0) {


### PR DESCRIPTION
Payloads can exceed MAX_PAYLOAD_SIZE, in which case the probe
will fail to send any data to the backend server. This was observed
with BERT payloads, but other payload types can exceed the maximum
size as well.

This patch truncates the payload if needed. It is better to receive
a truncated report than none.

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>