### PR TITLE
configure.ac: bump version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([telemetrics-client], [2.3.1], [https://clearlinux.org/])
+AC_INIT([telemetrics-client], [2.3.2], [https://clearlinux.org/])
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([1.14 -Wall -Werror -Wno-extra-portability foreign subdir-objects])
 AM_SILENT_RULES([yes])


### PR DESCRIPTION
Increase the version to 2.3.2 to reflect the fact that
bertprobe was entirely removed. The bertprobe functionality
was moved to klogscanner.

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>