### PR TITLE
crash_probe.c: process_corefile: reset frame counter

### DIFF
--- a/src/probes/crash_probe.c
+++ b/src/probes/crash_probe.c
@@ -396,6 +396,7 @@ static int process_corefile(nc_string **backtrace)
                 nc_string_free(*backtrace);
         }
         *backtrace = nc_string_dup("");
+        frame_counter = 0;
 
         if (dwfl_getthreads(d_core, thread_cb, backtrace) != DWARF_CB_OK) {
                 /* We aborted unwinding, due to too many frames.


### PR DESCRIPTION
process_corefile may be called twice due to retry logic.
Make sure frame_counter is initialized each time.

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>